### PR TITLE
Search across all word types

### DIFF
--- a/app/controllers/concerns/word_filter.rb
+++ b/app/controllers/concerns/word_filter.rb
@@ -72,7 +72,7 @@ module WordFilter
     )
 
     scope :filter_type, lambda { |type|
-      where(type: type.presence || "Noun")
+      where(type: type.presence || "")
     }
 
     scope :filter_wordquery, lambda { |query|

--- a/app/javascript/controllers/filter_controller.js
+++ b/app/javascript/controllers/filter_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
 
   connect() {
     const params = new URLSearchParams(window.location.search)
-    const type = params.get('filterrific[filter_type]') || 'Noun'
+    const type = params.get('filterrific[filter_type]') || ''
 
     if (this.nounTarget) {
       switch(type) {
@@ -20,13 +20,21 @@ export default class extends Controller {
           this.showAdjective()
           break
         case 'Noun':
-        default:
           this.showNoun()
+          break
+        default:
+          this.hideAll()
           break
       }
 
       document.getElementById(`filterrific_filter_type_${type.toLowerCase()}`).checked = true
     }
+  }
+
+  hideAll() {
+    this.nounTarget.classList.toggle("hidden", true)
+    this.verbTarget.classList.toggle("hidden", true)
+    this.adjectiveTarget.classList.toggle("hidden", true)
   }
 
   showNoun() {

--- a/app/views/filters/_form.html.haml
+++ b/app/views/filters/_form.html.haml
@@ -9,6 +9,9 @@
         %label= t 'activerecord.attributes.word.type'
         .flex.flex-col.md:flex-row.md:gap-4
           .flex.items-center.gap-2
+            = f.radio_button :filter_type, '', data: {action: "input->form-submission#search click->filter#hideAll"}
+            = f.label :filter_type, t('filter.all'), value: ''
+          .flex.items-center.gap-2
             = f.radio_button :filter_type, 'Noun', data: {action: "input->form-submission#search click->filter#showNoun"}
             = f.label :filter_type, t('activerecord.models.noun.one'), value: 'Noun'
           .flex.items-center.gap-2

--- a/config/locales/filter.de.yml
+++ b/config/locales/filter.de.yml
@@ -3,6 +3,7 @@ de:
     title: Filter
     apply: Filtern
     reset: Filter löschen
+    all: Alle
     and: und
     or: oder
     wordstarts: Wortanfang

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -1,37 +1,66 @@
 # frozen_string_literal: true
 
 RSpec.describe "word filter" do
-  before do
-    words.each do |word|
-      create :noun, name: word
+  describe "filtering words" do
+    before do
+      words.each do |word|
+        create :noun, name: word
+      end
+
+      visit search_path
     end
 
-    visit search_path
-  end
-
-  let(:words) do
-    %w[
-      Abfall
-      Abend
-      Bach
-    ]
-  end
-
-  it "filters words", js: true do
-    words.each do |word|
-      expect(page).to have_content word
+    let(:words) do
+      %w[
+        Abfall
+        Abend
+        Bach
+      ]
     end
 
-    fill_in t("filter.wordstarts"), with: "a"
+    it "filters words", js: true do
+      words.each do |word|
+        expect(page).to have_content word
+      end
 
-    expect(page).to have_content "Abfall"
-    expect(page).to have_content "Abend"
-    expect(page).not_to have_content "Bach"
+      fill_in t("filter.wordstarts"), with: "a"
 
-    click_on t("filter.reset")
+      expect(page).to have_content "Abfall"
+      expect(page).to have_content "Abend"
+      expect(page).not_to have_content "Bach"
 
-    words.each do |word|
-      expect(page).to have_content word
+      click_on t("filter.reset")
+
+      words.each do |word|
+        expect(page).to have_content word
+      end
+    end
+  end
+
+  describe "filter specific word types" do
+    let!(:noun) { create :noun, name: "Abend" }
+    let!(:verb) { create :verb, name: "abbauen" }
+    let!(:adjective) { create :adjective, name: "abstrakt" }
+
+    before do
+      visit search_path
+      fill_in t("filter.wordstarts"), with: "ab"
+    end
+
+    it "filters a specific word type", js: true do
+      expect(page).to have_content "Abend"
+      expect(page).to have_content "abbauen"
+      expect(page).to have_content "abstrakt"
+
+      choose t("activerecord.models.noun.one")
+      expect(page).to have_content "Abend"
+      expect(page).not_to have_content "abbauen"
+      expect(page).not_to have_content "abstrakt"
+
+      choose t("filter.all")
+      expect(page).to have_content "Abend"
+      expect(page).to have_content "abbauen"
+      expect(page).to have_content "abstrakt"
     end
   end
 end


### PR DESCRIPTION
Closes #5.

This adds an "all" option to the search.

Note that this goes into the `friendly_id` branch, only to avoid database troubles for convenience.

![screengrab-20221109-2023](https://user-images.githubusercontent.com/1394828/200922293-ed2d92cf-9ea3-4cb0-b5a5-b45a03839c25.gif)