### PR TITLE
Add article to noun title

### DIFF
--- a/app/views/nouns/show.html.haml
+++ b/app/views/nouns/show.html.haml
@@ -1,4 +1,9 @@
-= title_with_actions @noun.name
+- title = capture do
+  .flex.items-baseline.gap-1
+    - if @noun.genus.present?
+      .text-xl.font-normal= @noun.article_definite(case_number: 1, singular: true)
+    = @noun.name
+= title_with_actions title
 
 = two_column_card t('words.show.noun.title'), t('words.show.noun.description'), first: true do
   = box padding: false do


### PR DESCRIPTION
Closes #6.

Adds the singular article in front of the noun in the title:

![image](https://user-images.githubusercontent.com/1394828/201308604-b5911ab7-198d-4868-8ebf-3745149609d9.png)

If no genus is selected for the noun, no article is displayed.