### PR TITLE
Fix word history

### DIFF
--- a/app/views/words/_versions.html.haml
+++ b/app/views/words/_versions.html.haml
@@ -1,6 +1,6 @@
 - if can? :read_versions, word
   = two_column_card t('.title'), '' do
-    .flex.flex-col.gap-4.mt-6
+    .flex.flex-col.gap-4
       - versions = versions_with_changes word.versions
       - if versions.empty?
         = box do

--- a/db/migrate/20221111105512_convert_papertrail_yaml_to_json.rb
+++ b/db/migrate/20221111105512_convert_papertrail_yaml_to_json.rb
@@ -1,0 +1,23 @@
+class ConvertPapertrailYamlToJson < ActiveRecord::Migration[7.0]
+  def up
+    add_column :versions, :new_object, :jsonb
+    add_column :versions, :new_object_changes, :jsonb
+
+    PaperTrail::Version.where.not(object: nil).find_each do |version|
+      version.update_column(:new_object, YAML.unsafe_load(version.object))
+
+      if version.object_changes
+        version.update_column(
+          :new_object_changes,
+          YAML.unsafe_load(version.object_changes)
+        )
+      end
+    end
+
+    remove_column :versions, :object
+    remove_column :versions, :object_changes
+
+    rename_column :versions, :new_object, :object
+    rename_column :versions, :new_object_changes, :object_changes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_04_110839) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_11_105512) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -264,9 +264,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_04_110839) do
     t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
-    t.text "object"
     t.datetime "created_at"
-    t.text "object_changes"
+    t.jsonb "object"
+    t.jsonb "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -369,4 +369,22 @@ RSpec.describe Word do
       expect(word.consonant_vowel).to eq "VKKVK"
     end
   end
+
+  describe "tracks change history" do
+    subject(:word) { create :noun, name: "Adler" }
+
+    it "tracks a change of the name itself" do
+      word.update!(name: "Haus")
+
+      expect(word.versions.count).to eq 2
+
+      created_version = word.versions.find { |version| version.event == "create" }
+      updated_version = word.versions.find { |version| version.event == "update" }
+
+      expect(created_version.changeset).not_to be_empty
+      expect(updated_version.changeset).not_to be_empty
+
+      expect(updated_version.changeset.except("updated_at")).to eq({"consonant_vowel" => ["VKKVK", "KVVK"], "name" => ["Adler", "Haus"]})
+    end
+  end
 end


### PR DESCRIPTION
There is an incompatibility between Rails 7 and newer versions of paper_trail. By default paper_trail uses YAML to serialize objects and changes. ActiveRecord nowadays only allows safe YAML to be loaded, which is not the case for objects and changes.

This causes the following error when loading changesets:

```ruby
changes = Word.first.versions.last.object_changes
PaperTrail.serializer.load(ch)
~/.rbenv/versions/3.1.0/lib/ruby/3.1.0/psych/class_loader.rb:99:in `find': Tried to load unspecified class: Time (Psych::DisallowedClass)
```

Which causes the displayed change history to be empty as empty changes are reported. The changes are still recorded correctly in the database though.

We therefore convert the YAML based column to use JSON instead.

## Caveats

* Changing an example sentence does not create a new version, because an associated object changes. This worked before in paper_trail, but has been extracted into a [separate gem](https://github.com/westonganger/paper_trail-association_tracking). If we want that to work, we need to use the plugin, put the associated objects also under change tracking and merge the changes from the word and its association manually to be displayed in the view.
* Mainly to safe time, the migration does not have a rollback.
