### PR TITLE
Search | Allow function words to be found correctly

### DIFF
--- a/app/controllers/function_words_controller.rb
+++ b/app/controllers/function_words_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class FunctionWordsController < ApplicationController
+class FunctionWordsController < PublicController
   load_and_authorize_resource
 
   def index

--- a/app/javascript/controllers/filter_controller.js
+++ b/app/javascript/controllers/filter_controller.js
@@ -54,4 +54,8 @@ export default class extends Controller {
     this.verbTarget.classList.toggle("hidden", true)
     this.adjectiveTarget.classList.toggle("hidden", false)
   }
+
+  showFunctionWord() {
+    this.hideAll()
+  }
 }

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,6 +9,7 @@ class Ability
     can :read, Noun
     can :read, Verb
     can :read, Adjective
+    can :read, FunctionWord
 
     if user.present?
       can %i[show edit update destroy], User, %i[first_name last_name avatar email password], id: user.id

--- a/app/views/filters/_form.html.haml
+++ b/app/views/filters/_form.html.haml
@@ -20,6 +20,9 @@
           .flex.items-center.gap-2
             = f.radio_button :filter_type, 'Adjective', data: {action: "input->form-submission#search click->filter#showAdjective"}
             = f.label :filter_type, t('activerecord.models.adjective.one'), value: 'Adjective'
+          .flex.items-center.gap-2
+            = f.radio_button :filter_type, 'FunctionWord', data: {action: "input->form-submission#search click->filter#showFunctionWord"}
+            = f.label :filter_type, t('activerecord.models.function_word.one'), value: 'FunctionWord'
 
       .mt-4.input
         = filter_text_field f, :wordstarts

--- a/app/views/function_words/_function_word.html.haml
+++ b/app/views/function_words/_function_word.html.haml
@@ -1,3 +1,7 @@
-= link_if(can?(:show, function_word), function_word, id: dom_id(function_word)) do
-  = box class: 'h-full' do
-    = function_word.name
+= link_if(can?(:show, function_word), function_word, data: { turbo_frame: '_top' }, id: dom_id(function_word)) do
+  = box padding: false, class: 'h-full' do
+    .flex.h-full
+      .bg-gray-50.w-24.h-24
+      .px-4.py-5.sm:px-6
+        .flex.items-baseline.gap-1
+          .text-xl.font-medium= function_word.name

--- a/app/views/function_words/index.html.haml
+++ b/app/views/function_words/index.html.haml
@@ -5,4 +5,5 @@
 
 .pagination-with-actions
   = paginate @function_words
-  = link_to t('.new'), new_function_word_path, class: 'button primary'
+  - if can? :create, FunctionWord
+    = link_to t('.new'), new_function_word_path, class: 'button primary'

--- a/app/views/function_words/show.html.haml
+++ b/app/views/function_words/show.html.haml
@@ -15,6 +15,7 @@
     
       = render(list.add(Word.human_attribute_name(:written_syllables))) do
         = @function_word.written_syllables
-    
+
 .pagination-with-actions
-  = link_to t('actions.edit'), edit_function_word_path(@function_word), class: 'button primary'
+  - if can? :edit, @function_word
+    = link_to t('actions.edit'), edit_function_word_path(@function_word), class: 'button primary'


### PR DESCRIPTION
Fixes #26.

## Changes

* Allows everyone (also guests) to see function words (including their index and detail page). Creating function words or editing still requires privileges.
* Adds function word to be searchable by type
![image](https://user-images.githubusercontent.com/1394828/201335472-1eab3057-5038-4ef0-98d0-deba65e48b8f.png)
* Fix layout and click on function words in search results. We always display a grey box on the left as function words cannot have images. However, when displayed among other words, it looks strange without the grey box.
![image](https://user-images.githubusercontent.com/1394828/201335704-b7c19041-e1e2-4e1f-896f-2f049a0ec7b0.png)
