### PR TITLE
Allow slugs to be edited

### DIFF
--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -72,9 +72,13 @@ class Word < ApplicationRecord
   scope :ordered_lexigraphically, -> { order(:name) }
 
   before_save :set_consonant_vowel
+  before_save :sanitize_slug
+
+  validates :slug, presence: true, uniqueness: true
 
   ATTRIBUTES = [
     :name,
+    :slug,
     :image,
     :meaning,
     :meaning_long,
@@ -138,5 +142,9 @@ class Word < ApplicationRecord
       .downcase
       .gsub(/[^[:alpha:]]/, "")
       .chars
+  end
+
+  def sanitize_slug
+    slug.downcase!
   end
 end

--- a/app/views/words/_general_form.html.haml
+++ b/app/views/words/_general_form.html.haml
@@ -2,6 +2,7 @@
   = box do
     = f.input :type, input_html: {value: word.class.model_name.human}, disabled: true, label: Word.human_attribute_name(:type)
     = f.input :name, autofocus: true, label: Word.human_attribute_name(:name) if show_name
+    = f.input :slug, label: Word.human_attribute_name(:slug) unless f.object.new_record?
     = f.input :image, label: Word.human_attribute_name(:image)
     = f.input :meaning, label: Word.human_attribute_name(:meaning)
     = f.input :meaning_long, as: :text, label: Word.human_attribute_name(:meaning_long)

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -75,6 +75,7 @@ de:
       word:
         type: Wortart
         name: Wort
+        slug: URL Term
         image: Bild
         hierarchy: Kategorie
         topics: Themen

--- a/spec/features/friendly_id_spec.rb
+++ b/spec/features/friendly_id_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe "friendly ID" do
+  let(:noun) { create :noun, name: "Ticken" }
+  let(:verb) { create :noun, name: "ticken" }
+  let(:admin) { create :user, role: "Admin" }
+
+  before do
+    login_as admin
+  end
+
+  describe "edit a slug" do
+    it "allows to edit a slug" do
+      expect(noun.slug).to eq "ticken"
+      expect(verb.slug).to eq "ticken-2"
+
+      visit edit_verb_path(verb)
+      expect(page).to have_field t("activerecord.attributes.word.slug"), with: "ticken-2"
+      fill_in t("activerecord.attributes.word.slug"), with: "ticken-verb"
+      click_on t("helpers.submit.update")
+
+      expect(verb.reload.slug).to eq "ticken-verb"
+    end
+  end
+end

--- a/spec/models/friendly_id_spec.rb
+++ b/spec/models/friendly_id_spec.rb
@@ -33,4 +33,16 @@ RSpec.describe "friendly ID" do
       expect(noun3.slug).to eq "bauer-3"
     end
   end
+
+  describe "update a slug" do
+    let(:noun) { create :noun, name: "Bauer" }
+
+    it "lowercases the slug" do
+      expect(noun.slug).to eq "bauer"
+
+      noun.update!(slug: "ADLer")
+
+      expect(noun.slug).to eq "adler"
+    end
+  end
 end


### PR DESCRIPTION
Closes #32.

## Changes

* Add field to edit the slug (only when editing, not when creating).
![image](https://user-images.githubusercontent.com/1394828/201343139-16fa3e6e-86ff-49ca-8e45-3689efc46b36.png)
* Make sure slugs are lowercased when updated

## Caveats

* We hide the input field for the slug when creating new words. For tech savy people it is still possible to set the initial slug by editing the HTTP request. As the slug is editable afterwards I can't think of a way this could be exploited. I therefore decided to abstain from introducing verbose backend logic to disallow the slug on creation.
* I called the slug field "URL Term". Let me know if you know a better wording or if we should just call it "Slug" in German as well.
* I decided not to show the slug on the detail page of the word for simplicity. Let me know if it makes sense to add it there as well!