### PR TITLE
Wörterklinik | Add word lists to learning groups

### DIFF
--- a/app/controllers/learning_pleas_controller.rb
+++ b/app/controllers/learning_pleas_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class LearningPleasController < ApplicationController
+  load_and_authorize_resource :school
+  load_and_authorize_resource :learning_group, through: :school
+  load_and_authorize_resource through: :learning_group
+
+  before_action :set_lists, only: :new
+
+  def new
+  end
+
+  def create
+    if @learning_plea.save
+      redirect_to [@school, @learning_group], notice: t("notices.learning_pleas.created", name: @learning_plea.list)
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    destroyed = @learning_plea.destroy
+    notice = if destroyed
+      {notice: t("notices.learning_pleas.destroyed", name: @learning_plea.list)}
+    else
+      {alert: t("alerts.learning_pleas.destroyed", name: @learning_plea.list)}
+    end
+
+    redirect_to [@school, @learning_plea.learning_group], notice
+  end
+
+  private
+
+  def learning_plea_params
+    params.require(:learning_plea).permit(
+      :list_id
+    )
+  end
+
+  def set_lists
+    @lists = List
+      .where(visibility: :public)
+      .where.not(id: @learning_group.lists.to_a)
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -20,7 +20,7 @@ class Ability
         can %i[read accept_invitation], LearningGroup
         can :read, School
 
-        can %i[read read_students], LearningGroup, students: {id: user.id}
+        can %i[read read_students read_lists], LearningGroup, students: {id: user.id}
         can :show, School, learning_groups: {students: {id: user.id}}
         can :create, :learning_group_membership_requests
 
@@ -52,10 +52,11 @@ class Ability
 
         # User management
         can :read, User, role: "Student"
-        can %i[crud invite read_students], LearningGroup, teacher_id: user.id
+        can %i[crud invite read_students read_lists], LearningGroup, teacher_id: user.id
         can :crud, LearningGroupMembership, learning_group: {teacher_id: user.id}
         can %i[read read_teachers], School, teaching_assignments: {teacher_id: user.id}
         can %i[accept reject], :learning_group_membership_requests
+        can :crud, LearningPlea, learning_group: {teacher_id: user.id}
 
       when "Admin"
         can :manage, Noun
@@ -86,6 +87,7 @@ class Ability
         can :manage, TeachingAssignment
         can :manage, LearningGroup
         can :manage, LearningGroupMembership
+        can :manage, LearningPlea
       end
     end
   end

--- a/app/models/learning_group.rb
+++ b/app/models/learning_group.rb
@@ -12,6 +12,8 @@ class LearningGroup < ApplicationRecord
   has_many :learning_group_memberships, dependent: :destroy
   has_many :granted_learning_group_memberships, -> { with_access("granted") }, class_name: "LearningGroupMembership"
   has_many :students, through: :granted_learning_group_memberships
+  has_many :learning_pleas
+  has_many :lists, through: :learning_pleas
 
   has_secure_token :invitation_token, length: 42
 

--- a/app/models/learning_plea.rb
+++ b/app/models/learning_plea.rb
@@ -1,0 +1,4 @@
+class LearningPlea < ApplicationRecord
+  belongs_to :learning_group
+  belongs_to :list
+end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -3,10 +3,16 @@ class List < ApplicationRecord
 
   belongs_to :user
   has_and_belongs_to_many :words
+  has_many :learning_pleas
+  has_many :learning_groups, through: :learning_pleas
 
   enumerize :visibility, in: %i[private public], default: :private
 
   scope :of_user, ->(user) { where(user:) }
 
   validates :name, presence: true
+
+  def to_s
+    name
+  end
 end

--- a/app/views/learning_groups/show.html.haml
+++ b/app/views/learning_groups/show.html.haml
@@ -20,7 +20,7 @@
           = render 'invitation', learning_group: @learning_group
 
 - if can? :read_students, @learning_group
-  = two_column_card Student.model_name.human(count: 2), "", first: true do
+  = two_column_card Student.model_name.human(count: 2), "" do
     = box padding: false do
       - if can? :create, LearningGroupMembership.new(learning_group: @learning_group)
         .px-4.py-5.flex.justify-end
@@ -39,3 +39,19 @@
                     .flex.gap-1
                       = button_to t('.accept'), school_learning_group_learning_group_membership_requests_accept_path(@school, @learning_group, membership), method: :post, class: 'button primary'
                       = button_to t('.reject'), school_learning_group_learning_group_membership_requests_reject_path(@school, @learning_group, membership), method: :post, class: 'button'
+
+- if can? :read_lists, @learning_group
+  = two_column_card List.model_name.human(count: 2), "" do
+    = box padding: false do
+      - if can? :create, LearningPlea.new(learning_group: @learning_group)
+        .px-4.py-5.flex.justify-end
+          = link_to t('.assign_list'), new_school_learning_group_learning_plea_path(@school, @learning_group), class: 'button primary'
+
+      = box_description_list do |list|
+        - @learning_group.learning_pleas.each do |learning_plea|
+          %div{id: dom_id(learning_plea)}
+            = render(list.add(learning_plea.list)) do
+              %div
+              - if can? :edit, learning_plea
+                .ml-4.flex-shrink-0
+                  = button_to t('actions.remove'), school_learning_group_learning_plea_path(@school, @learning_group, learning_plea), method: :delete, class: 'button'

--- a/app/views/learning_pleas/new.html.haml
+++ b/app/views/learning_pleas/new.html.haml
@@ -1,0 +1,11 @@
+%h1= t '.title'
+
+= index_grid do
+  - @lists.each do |list|
+    = box do
+      .flex.justify-between.items-center{id: dom_id(list)}
+        = list
+        = form_with url: school_learning_group_learning_pleas_path(@school, @learning_group) do |f|
+          = f.hidden_field 'learning_plea[list_id]', value: list.id
+          = button_tag :submit, class: 'button' do
+            = t('.assign')

--- a/config/locales/notices.de.yml
+++ b/config/locales/notices.de.yml
@@ -32,6 +32,9 @@ de:
       accepted_error: Die Schüler*in konnte der Lerngruppe nicht hinzugefügt werden.
       rejected: Die Anfrage wurde abgelehnt.
       rejected_error: Die Anfrage konnte nicht abgelehnt werden.
+    learning_pleas:
+      created: Die Wortliste %{name} wurde hinzugefügt.
+      destroyed: Die Wortliste %{name} wurde entfernt.
     sources:
       created: Die Quelle %{name} wurde erstellt.
       updated: Die Quelle %{name} wurde gespeichert.
@@ -55,6 +58,8 @@ de:
       destroyed: Die Lehrer*in %{name} konnte nicht entfernt werden.
     learning_group_membership:
       destroyed: Die Schüler*in %{name} konnte nicht entfernt werden.
+    learning_plea:
+      destroyed: Die Wörterliste %{name} konnte nicht entfernt werden.
     sources:
       destroyed: Die Quelle %{name} konnte nicht gelöscht werden.
     shared:

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -128,6 +128,10 @@ de:
     new:
       title: Schüler*in hinzufügen
       assign: Hinzufügen
+  learning_pleas:
+    new:
+      title: Wortliste hinzufügen
+      assign: Hinzufügen
   function_words:
     index:
       new: Neues Funktionswort
@@ -220,6 +224,7 @@ de:
       request_access: Gruppe beitreten
       accept: Zulassen
       reject: Ablehnen
+      assign_list: Wortliste hinzufügen
     new:
       title: Neue Lerngruppe
     edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
           post "requests/reject", to: "requests#reject"
         end
       end
+      resources :learning_pleas, only: %i[new create destroy]
     end
   end
   resources :compounds, only: :index

--- a/db/migrate/20221116170556_create_learning_pleas.rb
+++ b/db/migrate/20221116170556_create_learning_pleas.rb
@@ -1,0 +1,10 @@
+class CreateLearningPleas < ActiveRecord::Migration[7.0]
+  def change
+    create_table :learning_pleas do |t|
+      t.references :learning_group, null: false, foreign_key: true
+      t.references :list, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_13_172929) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_16_170556) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -144,6 +144,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_172929) do
     t.index ["theme_function_word_id"], name: "index_learning_groups_on_theme_function_word_id"
     t.index ["theme_noun_id"], name: "index_learning_groups_on_theme_noun_id"
     t.index ["theme_verb_id"], name: "index_learning_groups_on_theme_verb_id"
+  end
+
+  create_table "learning_pleas", force: :cascade do |t|
+    t.bigint "learning_group_id", null: false
+    t.bigint "list_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["learning_group_id"], name: "index_learning_pleas_on_learning_group_id"
+    t.index ["list_id"], name: "index_learning_pleas_on_list_id"
   end
 
   create_table "lists", force: :cascade do |t|
@@ -396,6 +405,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_172929) do
   add_foreign_key "learning_groups", "themes", column: "theme_noun_id"
   add_foreign_key "learning_groups", "themes", column: "theme_verb_id"
   add_foreign_key "learning_groups", "users", column: "teacher_id"
+  add_foreign_key "learning_pleas", "learning_groups"
+  add_foreign_key "learning_pleas", "lists"
   add_foreign_key "lists", "users"
   add_foreign_key "themes", "users"
   add_foreign_key "users", "themes", column: "theme_adjective_id"

--- a/spec/features/learning_groups_spec.rb
+++ b/spec/features/learning_groups_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe "learning groups" do
         expect(learning_group.invitable).to be false
       end
     end
+
+    it "adds a word list" do
+      word_list = create :list, user: teacher, visibility: :public
+
+      visit school_learning_group_path(school, learning_group)
+      click_on t("learning_groups.show.assign_list")
+      expect(page).to have_content t("learning_pleas.new.title")
+
+      click_on t("learning_pleas.new.assign")
+
+      expect(learning_group.lists).to match_array [word_list]
+    end
   end
 
   context "as a student" do


### PR DESCRIPTION
Related to #16.

This allows to add word lists to learning groups.

![image](https://user-images.githubusercontent.com/1394828/202555426-4d351f33-82b8-4af3-a5d8-87936d040d15.png)
