### PR TITLE
Hide 'new school' button for teachers

### DIFF
--- a/app/views/schools/index.html.haml
+++ b/app/views/schools/index.html.haml
@@ -3,5 +3,6 @@
 = index_grid do
   = render @schools
 
-.pagination-with-actions
-  = link_to t('.new'), new_school_path, class: 'button primary'
+- if can? :create, School
+  .pagination-with-actions
+    = link_to t('.new'), new_school_path, class: 'button primary'


### PR DESCRIPTION
This fixes the display of the new school button, depending on if the current user is able to create a new school or not.