### PR TITLE
Wörterklinik | Change words for students when lists change

### DIFF
--- a/app/controllers/learning_pleas_controller.rb
+++ b/app/controllers/learning_pleas_controller.rb
@@ -12,9 +12,7 @@ class LearningPleasController < ApplicationController
 
   def create
     if @learning_plea.save
-      @learning_group.students.each do |student|
-        student.flashcard_list(Flashcards::SECTIONS.first).words << @learning_plea.list.words
-      end
+      Flashcards.add_list(@learning_group, @learning_plea.list)
 
       redirect_to [@school, @learning_group], notice: t("notices.learning_pleas.created", name: @learning_plea.list)
     else

--- a/app/controllers/learning_pleas_controller.rb
+++ b/app/controllers/learning_pleas_controller.rb
@@ -22,6 +22,8 @@ class LearningPleasController < ApplicationController
 
   def destroy
     destroyed = @learning_plea.destroy
+    Flashcards.remove_obsolete_words(@learning_group)
+
     notice = if destroyed
       {notice: t("notices.learning_pleas.destroyed", name: @learning_plea.list)}
     else

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -54,12 +54,16 @@ class ListsController < ApplicationController
   def add_word
     @word = Word.find params[:word_id]
     @list.words << @word
+    @list.learning_groups.find_each do |learning_group|
+      Flashcards.add_list(learning_group, @list)
+    end
 
     redirect_to @list
   end
 
   def remove_word
     @list.words.delete(params[:word_id])
+    Flashcards.remove_word(@list, Word.find(params[:word_id]))
 
     redirect_to @list
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -24,7 +24,7 @@ class Ability
         can :show, School, learning_groups: {students: {id: user.id}}
         can :create, :learning_group_membership_requests
 
-        can %i[crud add_word remove_word move_word], List, {user:}
+        can %i[crud add_word remove_word move_word], List, {user_id: user.id}
         can :index, :flashcard
 
       when "Teacher"
@@ -49,7 +49,7 @@ class Ability
 
         can :read, Theme, visibility: :public
         can :crud, Theme, {user:}
-        can %i[crud add_word remove_word create_private], List, {user:}
+        can %i[crud add_word remove_word create_private], List, {user_id: user.id}
 
         # User management
         can :read, User, role: "Student"

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -6,15 +6,20 @@ class Student < User
 
   has_many :learning_group_memberships, dependent: :destroy
   has_many :learning_groups, through: :learning_group_memberships
+  has_many :flashcard_lists, -> { where.not(flashcard_section: nil) }, class_name: "List", foreign_key: :user_id
 
   after_create :setup_flashcards
 
-  def flashcard_list(flashcard_section)
-    lists.unscoped.find_by(flashcard_section:)
+  def first_flashcard_list
+    flashcard_list(Flashcards::SECTIONS.first)
   end
 
-  def flashcard_lists
-    lists.unscoped.where.not(flashcard_section: nil)
+  def flashcard_list(flashcard_section)
+    flashcard_lists.find_by(flashcard_section:)
+  end
+
+  def word_in_flashcards?(word)
+    flashcard_lists.joins(:words).exists?("words.id": word.id)
   end
 
   private

--- a/app/services/flashcards.rb
+++ b/app/services/flashcards.rb
@@ -2,4 +2,14 @@
 
 class Flashcards
   SECTIONS = (1..5).to_a
+
+  def self.add_list(learning_group, list)
+    learning_group.students.each do |student|
+      list.words.each do |word|
+        next if student.word_in_flashcards?(word)
+
+        student.first_flashcard_list.words << word
+      end
+    end
+  end
 end

--- a/app/services/flashcards.rb
+++ b/app/services/flashcards.rb
@@ -4,11 +4,31 @@ class Flashcards
   SECTIONS = (1..5).to_a
 
   def self.add_list(learning_group, list)
-    learning_group.students.each do |student|
+    learning_group.students.find_each do |student|
       list.words.each do |word|
         next if student.word_in_flashcards?(word)
 
         student.first_flashcard_list.words << word
+      end
+    end
+  end
+
+  def self.remove_word(list, word)
+    list.learning_groups.find_each do |learning_group|
+      remove_obsolete_words(learning_group)
+    end
+  end
+
+  def self.remove_obsolete_words(learning_group)
+    valid_word_ids = learning_group.lists.joins(:words).pluck("words.id")
+
+    learning_group.students.find_each do |student|
+      SECTIONS.each do |section|
+        list = student.flashcard_list(section)
+
+        obsolete_word_ids = list.words.pluck(:id) - valid_word_ids
+
+        list.words.delete(Word.find(obsolete_word_ids)) if obsolete_word_ids.present?
       end
     end
   end

--- a/app/views/learning_groups/show.html.haml
+++ b/app/views/learning_groups/show.html.haml
@@ -50,7 +50,8 @@
       = box_description_list do |list|
         - @learning_group.learning_pleas.each do |learning_plea|
           %div{id: dom_id(learning_plea)}
-            = render(list.add(learning_plea.list)) do
+            - link_to_list = link_to_if(can?(:read, learning_plea.list), learning_plea.list, list_path(learning_plea.list))
+            = render(list.add(link_to_list)) do
               %div
               - if can? :edit, learning_plea
                 .ml-4.flex-shrink-0

--- a/app/views/lists/show.html.haml
+++ b/app/views/lists/show.html.haml
@@ -20,7 +20,7 @@
 = two_column_card Word.model_name.human(count: 2), t('shared.word_count', word_count: @words.total_count, words: Word.model_name.human(count: @words.total_count)) do
   = box padding: false, class: 'striped' do
     - @words.each do |word|
-      .flex.justify-between.p-4
+      .flex.justify-between.p-4{id: dom_id(word)}
         = link_to word.name, word
         - if can? :remove_word, @list
           = button_to remove_word_list_path(@list, word_id: word.id), method: :delete, title: t('actions.remove') do

--- a/spec/features/flashcards_spec.rb
+++ b/spec/features/flashcards_spec.rb
@@ -18,12 +18,14 @@ RSpec.describe "flash cards" do
     let(:noun1) { create :noun, name: "Adler" }
     let(:noun2) { create :noun, name: "Bauer" }
 
-    it "adds words to the first section" do
+    before do
       word_list.words << noun1
       word_list.words << noun2
       LearningGroupMembership.create!(learning_group:, student:, access: :granted)
       login_as teacher
+    end
 
+    it "adds words to the first section" do
       visit school_learning_group_path(school, learning_group)
       click_on t("learning_groups.show.assign_list")
       expect(page).to have_content t("learning_pleas.new.title")

--- a/spec/features/flashcards_spec.rb
+++ b/spec/features/flashcards_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "flash cards" do
       login_as teacher
     end
 
-    it "adds words to the first section" do
+    it "adds words to the first section and removes the word when list is removed" do
       visit school_learning_group_path(school, learning_group)
       click_on t("learning_groups.show.assign_list")
       expect(page).to have_content t("learning_pleas.new.title")
@@ -38,6 +38,53 @@ RSpec.describe "flash cards" do
       visit flashcards_path
       expect(page).to have_content noun1.name
       expect(page).to have_content noun2.name
+
+      # Remove list
+      login_as teacher
+      visit school_learning_group_path(school, learning_group)
+      within "##{dom_id(learning_group.learning_pleas.first)}" do
+        click_on t("actions.remove")
+      end
+
+      login_as student
+      visit flashcards_path
+      expect(page).not_to have_content noun1.name
+      expect(page).not_to have_content noun2.name
+    end
+
+    it "adds and removes words when modifying the list" do
+      visit school_learning_group_path(school, learning_group)
+      click_on t("learning_groups.show.assign_list")
+      expect(page).to have_content t("learning_pleas.new.title")
+      click_on t("learning_pleas.new.assign")
+
+      expect(learning_group.lists).to match_array [word_list]
+      expect(student.flashcard_list(1).words).to match_array [noun1, noun2]
+
+      # Add new word
+      noun3 = create :noun, name: "Baum"
+      visit noun_path(noun3)
+      select word_list.name
+      click_on I18n.t("words.show.lists.add")
+
+      login_as student
+      visit flashcards_path
+      expect(page).to have_content noun1.name
+      expect(page).to have_content noun2.name
+      expect(page).to have_content noun3.name
+
+      # Remove word from list
+      login_as teacher
+      visit list_path(word_list)
+      within "##{dom_id(noun3)}" do
+        click_on I18n.t("actions.remove")
+      end
+
+      login_as student
+      visit flashcards_path
+      expect(page).to have_content noun1.name
+      expect(page).to have_content noun2.name
+      expect(page).not_to have_content noun3.name
     end
   end
 end

--- a/spec/models/flashcards_spec.rb
+++ b/spec/models/flashcards_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe "flashcards" do
+  context "with the same word on multiple lists" do
+    let!(:learning_group) { create :learning_group }
+    let(:list1) { create :list }
+    let(:list2) { create :list }
+    let(:student) { create :student }
+    let(:noun1) { create :noun, name: "Adler" }
+    let(:noun2) { create :noun, name: "Bauer" }
+
+    before do
+      list1.words << [noun1, noun2]
+      list2.words << [noun1]
+      LearningGroupMembership.create!(learning_group:, student:, access: :granted)
+    end
+
+    it "adds the word only once" do
+      expect(student.first_flashcard_list.words).to be_empty
+
+      Flashcards.add_list(learning_group, list1)
+      expect(student.first_flashcard_list.words).to match_array [noun1, noun2]
+
+      Flashcards.add_list(learning_group, list2)
+      expect(student.first_flashcard_list.words).to match_array [noun1, noun2]
+    end
+
+    it "does not add the word when it is already in another flashcard section" do
+      student.flashcard_list(Flashcards::SECTIONS.second).words << noun1
+      expect(student.first_flashcard_list.words).to be_empty
+      expect(student.flashcard_list(Flashcards::SECTIONS.second).words).to match_array [noun1]
+
+      Flashcards.add_list(learning_group, list2)
+      expect(student.first_flashcard_list.words).to be_empty
+      expect(student.flashcard_list(Flashcards::SECTIONS.second).words).to match_array [noun1]
+
+      Flashcards.add_list(learning_group, list1)
+      expect(student.first_flashcard_list.words).to match_array [noun2]
+      expect(student.flashcard_list(Flashcards::SECTIONS.second).words).to match_array [noun1]
+    end
+  end
+end

--- a/spec/models/flashcards_spec.rb
+++ b/spec/models/flashcards_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "flashcards" do
     before do
       list1.words << [noun1, noun2]
       list2.words << [noun1]
+      learning_group.lists << [list1, list2]
       LearningGroupMembership.create!(learning_group:, student:, access: :granted)
     end
 
@@ -37,6 +38,24 @@ RSpec.describe "flashcards" do
       Flashcards.add_list(learning_group, list1)
       expect(student.first_flashcard_list.words).to match_array [noun2]
       expect(student.flashcard_list(Flashcards::SECTIONS.second).words).to match_array [noun1]
+    end
+
+    it "removes a word from the first section" do
+      expect(student.first_flashcard_list.words).to be_empty
+
+      Flashcards.add_list(learning_group, list1)
+      Flashcards.add_list(learning_group, list2)
+      expect(student.first_flashcard_list.words).to match_array [noun1, noun2]
+
+      # Do not remove word here, because it is still present on list2
+      list1.words.delete(noun1)
+      Flashcards.remove_word(list1, noun1)
+      expect(student.first_flashcard_list.words).to match_array [noun1, noun2]
+
+      # Now it is removed everywhere
+      list2.words.delete(noun1)
+      Flashcards.remove_word(list2, noun1)
+      expect(student.first_flashcard_list.words).to match_array [noun2]
     end
   end
 end


### PR DESCRIPTION
Related to #16.

## Changes

* Adding or removing a word from a list, adds or removes that word from the Wörterklinik of all students who have a connection to that list via a learning group
* Adding or removing a list from a learning group, will add or remove words from the Wörterklinik of the students of that learning group
* Ensures that words only appear once in the "Wörterklinik" of a student, even if the word appears in multiple word lists connected to the learning group