### PR TITLE
Themes | Change creation of themes to a 2-step process

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -196,4 +196,8 @@
   .dropzone {
     @apply bg-gray-300;
   }
+
+  .cm-scroller, .cm-content {
+    min-height: 10rem !important;
+  }
 }

--- a/app/views/themes/_form.html.haml
+++ b/app/views/themes/_form.html.haml
@@ -3,7 +3,6 @@
     = box_content do
       = f.input :name, autofocus: true
       = f.input :description
-      = f.input :word_type, include_blank: false, input_html: { 'data-code-editor-target': 'wordType' }
       = f.input :template, input_html: { 'data-code-editor-target': 'input' }
       %button.text-xs.text-gray-500(class="!mt-0" type="button" data-action="code-editor#insert")= t('.replace_with_default_theme.action')
       = f.input :visibility, include_blank: false

--- a/app/views/themes/edit.html.haml
+++ b/app/views/themes/edit.html.haml
@@ -1,4 +1,5 @@
 = title_with_actions t('.title') do
   = button_to t('actions.delete'), theme_path(@theme), class: 'button danger', method: :delete, data: { confirm: t('confirmations.shared.destroy', name: @theme.name) } if can?(:destroy, @theme)
 
-= render 'form'
+= simple_form_for @theme, html: { 'data-controller': 'code-editor reveal' } do |f|
+  = render 'form'

--- a/app/views/themes/new.html.haml
+++ b/app/views/themes/new.html.haml
@@ -1,3 +1,16 @@
 %h1= t '.title'
 
-= render 'form'
+= simple_form_for @theme, html: { 'data-controller': 'code-editor reveal' } do |f|
+  - if @theme.name.blank?
+    = box padding: false, 'data-reveal-target': 'item' do
+      = box_content do
+        = f.input :word_type, include_blank: false, input_html: { 'data-code-editor-target': 'wordType' }
+
+      = box_footer do
+        %button.button.primary(type="button" data-action='click->reveal#toggle click->code-editor#insert')= t 'actions.continue'
+
+    .hidden(data-reveal-target="item")
+      = render 'form'
+
+  - else
+    = render 'form'

--- a/config/locales/actions.de.yml
+++ b/config/locales/actions.de.yml
@@ -7,6 +7,7 @@ de:
     cancel: Abbrechen
     remove: Entfernen
     copy: Kopieren
+    continue: Weiter
   helpers:
     submit:
       create: Erstellen

--- a/spec/features/themes_spec.rb
+++ b/spec/features/themes_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe "themes for words" do
     it "does not allow JavaScript content", js: true do
       visit public_send("#{klass.model_name.plural}_path")
       click_on t("#{klass.model_name.plural}.index.new")
+      click_on t("actions.continue")
 
       fill_in "#{klass.model_name.singular}[name]", with: "Neuer Name"
       find(".cm-editor").click


### PR DESCRIPTION
Closes #51.

## Changes

* Change theme creation into a 2 step process:

![screengrab-20221122-0952](https://user-images.githubusercontent.com/1394828/203269226-4c423b2d-d7b2-41e9-bbec-3282e005d359.gif)

* Increase minimum size of template editor

![screengrab-20221122-0953](https://user-images.githubusercontent.com/1394828/203269388-0230bc10-88ac-4f80-89e2-1b3b69370496.gif)
