### PR TITLE
Fix showing of edit button depending on permissions

### DIFF
--- a/app/views/lists/show.html.haml
+++ b/app/views/lists/show.html.haml
@@ -1,5 +1,6 @@
 = title_with_actions @list.name do
-  = link_to t('actions.edit'), edit_list_path(@list), class: 'button primary'
+  - if can? :edit, @list
+    = link_to t('actions.edit'), edit_list_path(@list), class: 'button primary'
 
 = two_column_card List.model_name.human, "", first: true do
   = box padding: false do


### PR DESCRIPTION
The edit button of word lists was always shown. We should only show it if the user has permission to edit the list.