### PR TITLE
Add redirect for words to downcased URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "puma", "~> 6.0"
 gem "rails-i18n"
 gem "rb-gravatar"
 gem "redis", "~> 5.0" # Use Redis for Action Cable
+gem "route_downcaser"
 gem "ruby-vips"
 gem "sanitize"
 gem "simple_form"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,6 +302,8 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
+    route_downcaser (1.2.3)
+      activesupport (>= 3.2)
     rspec-core (3.12.0)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.0)
@@ -439,6 +441,7 @@ DEPENDENCIES
   rails-i18n
   rb-gravatar
   redis (~> 5.0)
+  route_downcaser
   rspec-rails
   ruby-vips
   sanitize

--- a/config/initializers/route_downcaser.rb
+++ b/config/initializers/route_downcaser.rb
@@ -1,0 +1,10 @@
+RouteDowncaser.configuration do |config|
+  # Use 301 to redirect to downcased URL
+  config.redirect = true
+
+  # We only want to redirect word URLs, i.e. URLs not containing a slash (`/`)
+  # anywhere but the beginning
+  config.exclude_patterns = [
+    /^\/.*\/+/i
+  ]
+end

--- a/spec/features/nouns_spec.rb
+++ b/spec/features/nouns_spec.rb
@@ -5,6 +5,37 @@ RSpec.describe "nouns" do
     it_behaves_like "CRUD", Noun
   end
 
+  describe "word URLs" do
+    let!(:noun) { create :noun, name: "Adler" }
+
+    it "matches word case insensitive" do
+      visit "/Adler"
+      expect(page).to have_current_path "/adler"
+      expect(page).to have_selector "h1", text: "Adler"
+
+      visit "/adler"
+      expect(page).to have_current_path "/adler"
+      expect(page).to have_selector "h1", text: "Adler"
+
+      visit "/AdLEr"
+      expect(page).to have_current_path "/adler"
+      expect(page).to have_selector "h1", text: "Adler"
+    end
+
+    it "does not redirect more complex routes" do
+      expect do
+        visit "/page/IMPRESSUM"
+      end.to raise_error ActionController::RoutingError
+      expect(page).to have_current_path "/page/IMPRESSUM"
+
+      visit "/page/impressum"
+      expect(page).to have_current_path "/page/impressum"
+
+      visit "/NoUNs"
+      expect(page).to have_current_path "/nouns"
+    end
+  end
+
   describe "change history" do
     let!(:word) { create :noun, name: "Buche" }
 


### PR DESCRIPTION
Closes #27.

## Changes

- Redirect `/HAUs` to `/haus` using a 301
- URLs with an additional slash in them, such as `/page/impressum`, are not redirected. This is mainly to avoid hard to track bugs in library code, such as Devise or ActiveStorage (e.g. when using case sensitive tokens in URLs). We still redirect index actions of controllers such as `/NOUNS` though.