### PR TITLE
Add cologne phonetics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "active_storage_svg_sanitizer"
 gem "bootsnap", require: false
 gem "cancancan"
 gem "clamped"
+gem "cologne_phonetics"
 gem "devise"
 gem "devise-i18n"
 gem "draper"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
     clamped (1.0.0)
     cliver (0.3.2)
     coderay (1.1.3)
+    cologne_phonetics (1.0.2)
     concurrent-ruby (1.1.10)
     connection_pool (2.3.0)
     crass (1.0.6)
@@ -410,6 +411,7 @@ DEPENDENCIES
   capybara
   capybara-screenshot
   clamped
+  cologne_phonetics
   cuprite
   debug
   devise

--- a/app/controllers/concerns/word_filter.rb
+++ b/app/controllers/concerns/word_filter.rb
@@ -123,7 +123,7 @@ module WordFilter
     scope :filter_cologne_phonetics, lambda { |query|
       return if query.blank?
 
-      where(cologne_phonetics: ColognePhonetics.encode(query))
+      where("cologne_phonetics ILIKE ?", "#{ColognePhonetics.encode(query)}%")
     }
 
     scope :filter_letters, lambda { |query|

--- a/app/controllers/concerns/word_filter.rb
+++ b/app/controllers/concerns/word_filter.rb
@@ -47,6 +47,7 @@ module WordFilter
         :filter_wordcontains,
         :filter_letters,
         :filter_syllablescontains,
+        :filter_cologne_phonetics,
         :filter_source,
         :filter_topic,
         :filter_hierarchy,
@@ -117,6 +118,12 @@ module WordFilter
         *syllables_terms,
         *written_syllables_terms
       )
+    }
+
+    scope :filter_cologne_phonetics, lambda { |query|
+      return if query.blank?
+
+      where(cologne_phonetics: ColognePhonetics.encode(query))
     }
 
     scope :filter_letters, lambda { |query|

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -73,6 +73,7 @@ class Word < ApplicationRecord
   before_save :set_consonant_vowel
   before_save :sanitize_slug
   before_save :sanitize_example_sentences
+  before_save :update_cologne_phonetics
 
   validates :slug, presence: true, uniqueness: true
 
@@ -160,5 +161,9 @@ class Word < ApplicationRecord
     example_sentences
       .map!(&:strip)
       .select!(&:present?)
+  end
+
+  def update_cologne_phonetics
+    self.cologne_phonetics = ColognePhonetics.encode(name)
   end
 end

--- a/app/views/filters/_form.html.haml
+++ b/app/views/filters/_form.html.haml
@@ -29,6 +29,7 @@
       = filter_text_field f, :wordcontains
       = filter_text_field f, :wordends
       = filter_text_field f, :syllablescontains
+      = filter_text_field f, :cologne_phonetics
       = filter_text_field f, :letters
       = filter_select_field f, :source, collection: Source.order(:name).map { |s| [s.name, s.id] }
       = filter_select_field f, :topic, collection: Topic.order(:name).map { |t| [t.name, t.id] }

--- a/app/views/shared/_filter.html.haml
+++ b/app/views/shared/_filter.html.haml
@@ -3,7 +3,7 @@
     .relative.rounded-md.shadow-sm.mx-2.md:mx-0
       .absolute.inset-y-0.left-0.pl-3.flex.items-center.pointer-events-none
         = heroicon 'magnifying-glass', options: {class: 'text-gray-500 sm:text-sm'}
-      = f.text_field :filter_wordcontains, data: {action: "input->form-submission#search"}, class: 'pl-12 pr-12 bg-gray-50', autofocus: true
+      = f.text_field :filter_cologne_phonetics, data: {action: "input->form-submission#search"}, class: 'pl-12 pr-12 bg-gray-50', autofocus: true
       .absolute.inset-y-0.right-0.flex.items-center
         = link_to reset_filterrific_url, class: 'pr-3 text-gray-500', title: t('filter.reset') do
           = heroicon 'x-mark'

--- a/config/locales/filter.de.yml
+++ b/config/locales/filter.de.yml
@@ -10,6 +10,7 @@ de:
     wordcontains: Wort enthält
     wordends: Wortende
     syllablescontains: Silben
+    cologne_phonetics: Phonetisch
     letters: verwendete Buchstaben
     source: Quelle
     topic: Thema

--- a/db/migrate/20221202144813_add_cologne_phonetics_to_words.rb
+++ b/db/migrate/20221202144813_add_cologne_phonetics_to_words.rb
@@ -1,0 +1,14 @@
+class AddColognePhoneticsToWords < ActiveRecord::Migration[7.0]
+  def change
+    add_column :words, :cologne_phonetics, :string
+    add_index :words, :cologne_phonetics
+
+    reversible do |change|
+      change.up do
+        Word.find_each do |word|
+          word.update_attribute(:cologne_phonetics, ColognePhonetics.encode(word.name))
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_02_092420) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_02_144813) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -377,6 +377,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_02_092420) do
     t.integer "function_type"
     t.string "type", null: false
     t.jsonb "example_sentences", default: [], null: false
+    t.string "cologne_phonetics"
+    t.index ["cologne_phonetics"], name: "index_words_on_cologne_phonetics"
     t.index ["genus_feminine_id"], name: "index_words_on_genus_feminine_id"
     t.index ["genus_id"], name: "index_words_on_genus_id"
     t.index ["genus_masculine_id"], name: "index_words_on_genus_masculine_id"

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -90,4 +90,22 @@ RSpec.describe "word filter" do
       expect(list.words).to match_array [noun, verb, adjective]
     end
   end
+
+  describe "by cologne phonetics" do
+    let!(:noun) { create :noun, name: "Fahrrad" }
+
+    before do
+      visit search_path
+    end
+
+    it "filters phonetically", js: true do
+      expect(page).to have_content "Fahrrad" # 372
+
+      fill_in t("filter.cologne_phonetics"), with: "Var" # 37
+      expect(page).not_to have_content "Fahrrad"
+
+      fill_in t("filter.cologne_phonetics"), with: "Vahrad" # 372
+      expect(page).to have_content "Fahrrad"
+    end
+  end
 end

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -102,6 +102,9 @@ RSpec.describe "word filter" do
       expect(page).to have_content "Fahrrad" # 372
 
       fill_in t("filter.cologne_phonetics"), with: "Var" # 37
+      expect(page).to have_content "Fahrrad"
+
+      fill_in t("filter.cologne_phonetics"), with: "Hau" # 0
       expect(page).not_to have_content "Fahrrad"
 
       fill_in t("filter.cologne_phonetics"), with: "Vahrad" # 372

--- a/spec/models/history_spec.rb
+++ b/spec/models/history_spec.rb
@@ -14,7 +14,11 @@ RSpec.describe "tracking change history" do
     expect(created_version.changeset).not_to be_empty
     expect(updated_version.changeset).not_to be_empty
 
-    expect(updated_version.changeset.except("updated_at")).to eq({"consonant_vowel" => ["VKKVK", "KVVK"], "name" => ["Adler", "Haus"]})
+    expect(updated_version.changeset.except("updated_at")).to eq({
+      "consonant_vowel" => ["VKKVK", "KVVK"],
+      "name" => ["Adler", "Haus"],
+      "cologne_phonetics" => ["0257", "08"]
+    })
   end
 
   it "tracks a change of an example sentence" do

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -381,4 +381,20 @@ RSpec.describe Word do
       end
     end
   end
+
+  describe "#cologne_phonetics" do
+    it "creates phonetics when creating a word" do
+      word = create :noun, name: "Adler"
+      expect(word.cologne_phonetics).to eq "0257"
+    end
+
+    it "updates phonetics when updating a word" do
+      word = create :noun, name: "Adler"
+      expect(word.cologne_phonetics).to eq "0257"
+
+      word.update!(name: "Haus")
+      word.reload
+      expect(word.cologne_phonetics).to eq "08"
+    end
+  end
 end


### PR DESCRIPTION
Closes #20.

This implements searching by cologne phonetics.

## Changes

* Adds `Words#cologne_phonetics` which updates whenever a word changes
* Add a filter function to search by cologne phonetics
* Add an input field to the power search
* Change the filter input fields of nouns, verbs and adjectives to use phonetic search

## Caveats

This does not yet implement the more complex searching behavior which changes for every added letter as proposed in #20.