### PR TITLE
Fix image URLs

### DIFF
--- a/config/initializers/route_downcaser.rb
+++ b/config/initializers/route_downcaser.rb
@@ -5,6 +5,7 @@ RouteDowncaser.configuration do |config|
   # We only want to redirect word URLs, i.e. URLs not containing a slash (`/`)
   # anywhere but the beginning
   config.exclude_patterns = [
-    /^\/seite\//i
+    /^\/seite\//i,
+    /^\/rails\//i
   ]
 end

--- a/spec/requests/nouns_controller_spec.rb
+++ b/spec/requests/nouns_controller_spec.rb
@@ -94,4 +94,22 @@ RSpec.describe NounsController, type: :request do
       ]
     end
   end
+
+  describe "images" do
+    before do
+      word.image.attach(
+        io: StringIO.new(File.read("spec/fixtures/files/avatar1.png")),
+        filename: "example.png"
+      )
+
+      ActiveStorage::Current.url_options = {host: "localhost"}
+    end
+
+    it "loads images correctly" do
+      expect(word.image).to be_attached
+
+      get word.image.url
+      expect(response).to be_successful
+    end
+  end
 end


### PR DESCRIPTION
Closes #101.

Image URLs of activestorage must not be downcased as the signed ID would then be invalid.