### PR TITLE
Schools | Add address

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "bootsnap", require: false
 gem "cancancan"
 gem "clamped"
 gem "cologne_phonetics"
+gem "country_select"
 gem "device_detector"
 gem "devise"
 gem "devise-i18n"
@@ -28,6 +29,7 @@ gem "liquid"
 gem "meta-tags"
 gem "paper_trail"
 gem "pg", "~> 1.4"
+gem "phony_rails"
 gem "propshaft"
 gem "puma", "~> 6.0"
 gem "rails-i18n"
@@ -41,6 +43,7 @@ gem "stimulus-rails"
 gem "tailwindcss-rails"
 gem "turbo-rails"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
+gem "validate_url"
 gem "view_component"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,10 @@ GEM
     cologne_phonetics (1.0.2)
     concurrent-ruby (1.1.10)
     connection_pool (2.3.0)
+    countries (5.2.0)
+      unaccent (~> 0.3)
+    country_select (8.0.0)
+      countries (~> 5.0)
     crass (1.0.6)
     cuprite (0.14.3)
       capybara (~> 3.0)
@@ -245,6 +249,10 @@ GEM
     parser (3.1.2.0)
       ast (~> 2.4.1)
     pg (1.4.5)
+    phony (2.20.1)
+    phony_rails (0.15.0)
+      activesupport (>= 3.0)
+      phony (>= 2.18.12)
     propshaft (0.6.4)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -375,10 +383,14 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
+    unaccent (0.4.0)
     unicode-display_width (2.1.0)
     unicorn (6.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
     view_component (2.78.0)
       activesupport (>= 5.0.0, < 8.0)
       concurrent-ruby (~> 1.0)
@@ -413,6 +425,7 @@ DEPENDENCIES
   capybara-screenshot
   clamped
   cologne_phonetics
+  country_select
   cuprite
   debug
   device_detector
@@ -439,6 +452,7 @@ DEPENDENCIES
   mina (= 1.2.4)
   paper_trail
   pg (~> 1.4)
+  phony_rails
   propshaft
   puma (~> 6.0)
   rails (~> 7.0.4)
@@ -457,6 +471,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   unicorn
+  validate_url
   view_component
   web-console
 

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -47,7 +47,15 @@ class SchoolsController < ApplicationController
 
   def school_params
     params.require(:school).permit(
-      :name
+      :name,
+      :street,
+      :zip_code,
+      :city,
+      :country,
+      :homepage_url,
+      :email,
+      :phone_number,
+      :fax_number
     )
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -4,8 +4,42 @@ class School < ApplicationRecord
   has_many :learning_groups
 
   validates_presence_of :name
+  validates_presence_of :zip_code
+  validates_presence_of :city
+  validates_presence_of :country
+  validates :homepage_url, url: {allow_blank: true}
+  validates :email, allow_blank: true, format: {with: URI::MailTo::EMAIL_REGEXP}
+  validates_plausible_phone :phone_number
+  validates_plausible_phone :fax_number
+
+  phony_normalize :phone_number
+  phony_normalize :fax_number
+
+  before_validation :ensure_homepage_scheme
 
   def to_s
     name
+  end
+
+  def city_with_zip_code
+    [zip_code, city].select(&:present?).join(" ")
+  end
+
+  def country_name
+    country_properties = ISO3166::Country[country]
+
+    return "" if country_properties.blank?
+
+    country_properties.translations[I18n.locale.to_s] ||
+      country_properties&.common_name ||
+      country_properties&.iso_short_name
+  end
+
+  private
+
+  def ensure_homepage_scheme
+    has_http_scheme = homepage_url&.downcase&.start_with?("http")
+
+    self.homepage_url = "https://#{homepage_url}" if homepage_url.present? && !has_http_scheme
   end
 end

--- a/app/views/schools/_form.html.haml
+++ b/app/views/schools/_form.html.haml
@@ -1,6 +1,14 @@
 = box do
   = simple_form_for @school do |f|
     = f.input :name, autofocus: true
+    = f.input :street
+    = f.input :zip_code
+    = f.input :city
+    = f.input :country, priority: ['DE']
+    = f.input :homepage_url
+    = f.input :email
+    = f.input :phone_number
+    = f.input :fax_number
 
     = f.submit
     = cancel_button schools_path

--- a/app/views/schools/_school.html.haml
+++ b/app/views/schools/_school.html.haml
@@ -1,3 +1,4 @@
 = link_if(can?(:show, school), school, id: dom_id(school)) do
   = box do
     .font-medium.text-md= school.name
+    .text-xs.text-gray-700= school.city_with_zip_code

--- a/app/views/schools/show.html.haml
+++ b/app/views/schools/show.html.haml
@@ -1,7 +1,28 @@
 = title_with_actions @school.name
 
+= two_column_card t('schools.show.contact'), "", first: true do
+  = box padding: false do
+    = box_description_list do |list|
+      = render(list.add(School.human_attribute_name(:address))) do
+        .flex.flex-col
+          %span= @school.street
+          %span= @school.city_with_zip_code
+          %span= @school.country_name
+
+      = render(list.add(School.human_attribute_name(:homepage_url))) do
+        = link_to_if @school.homepage_url.present?, @school.homepage_url, @school.homepage_url, target: '_blank', rel: 'noopener noreferrer'
+
+      = render(list.add(School.human_attribute_name(:email))) do
+        = mail_to @school.email
+
+      = render(list.add(School.human_attribute_name(:phone_number))) do
+        = phone_to @school.phone_number&.phony_formatted(format: :international)
+
+      = render(list.add(School.human_attribute_name(:fax_number))) do
+        = phone_to @school.fax_number&.phony_formatted(format: :international)
+
 - if can? :read_teachers, @school
-  = two_column_card Teacher.model_name.human(count: 2), "", first: true do
+  = two_column_card Teacher.model_name.human(count: 2), "" do
     = box padding: false do
       - if can? :create, TeachingAssignment.new(school: @school)
         .px-4.py-5.flex.justify-end

--- a/config/initializers/phony.rb
+++ b/config/initializers/phony.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+PhonyRails.default_country_code = "DE"

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -167,6 +167,17 @@ de:
         name: Bezeichnung
       compound_vocalalternation:
         name: Bezeichnung
+      school:
+        name: Name der Schule
+        street: Strasse und Nummer
+        zip_code: Postleitzahl
+        city: Ort
+        country: Land
+        homepage_url: Homepage
+        email: E-Mail Adresse
+        phone_number: Telefonnummer
+        fax_number: Faxnummer
+        address: Adresse
       learning_group:
         name: Bezeichnung
         teacher: Lehrer*in

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -109,6 +109,7 @@ de:
       new: Neue Schule
     show:
       assign_teacher: Lehrer*in hinzufügen
+      contact: Kontaktangaben
     new:
       title: Schule erstellen
     edit:

--- a/db/migrate/20221216132621_add_address_to_schools.rb
+++ b/db/migrate/20221216132621_add_address_to_schools.rb
@@ -1,0 +1,12 @@
+class AddAddressToSchools < ActiveRecord::Migration[7.0]
+  def change
+    add_column :schools, :street, :string
+    add_column :schools, :zip_code, :string
+    add_column :schools, :city, :string
+    add_column :schools, :country, :string
+    add_column :schools, :homepage_url, :string
+    add_column :schools, :email, :string
+    add_column :schools, :phone_number, :string
+    add_column :schools, :fax_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_06_090348) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_16_132621) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -211,6 +211,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_06_090348) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "street"
+    t.string "zip_code"
+    t.string "city"
+    t.string "country"
+    t.string "homepage_url"
+    t.string "email"
+    t.string "phone_number"
+    t.string "fax_number"
   end
 
   create_table "sources", force: :cascade do |t|

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -3,5 +3,8 @@
 FactoryBot.define do
   factory :school do
     name { "Grundschule Musterberg" }
+    zip_code { "60400" }
+    city { "Frankfurt" }
+    country { "DE" }
   end
 end

--- a/spec/features/schools_spec.rb
+++ b/spec/features/schools_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe "schools" do
     click_on t("schools.index.new")
 
     fill_in School.human_attribute_name(:name), with: "Mittelschule Musterhausen"
+    fill_in School.human_attribute_name(:zip_code), with: "60400"
+    fill_in School.human_attribute_name(:city), with: "Frankfurt"
+    select ISO3166::Country["DE"].translations["de"], from: School.human_attribute_name(:country), match: :first
 
     expect do
       click_on t("helpers.submit.create")


### PR DESCRIPTION
Closes #106.

![screengrab-20221216-1511](https://user-images.githubusercontent.com/1394828/208117002-af0a5b99-5710-42bf-a01a-33fa620afc99.gif)

## Changes

* Add address parameters to schools in database
* Add address parameters to form when creating new schools or editing them
![image](https://user-images.githubusercontent.com/1394828/208118070-2e112fa5-ece2-419a-99ed-e7224bc7de3c.png)

* Add address and contact details to `schools#show`
![image](https://user-images.githubusercontent.com/1394828/208118119-4c5c2e1f-1c84-4e36-90dd-87e6fccb7c43.png)

* Add zip code and city to `schools#index`
![image](https://user-images.githubusercontent.com/1394828/208118167-31fcac75-3afc-4ddf-a184-cfa2402b649a.png)

## Details

* Homepage, e-mail and phone numbers are clickable
* Homepage is validated as suggested. If the user enters an URL without the protocol, we assume `https` and add that. So you can enter `example.com` and we store `https://example.com` (the validation gem requires a protocol).
* E-mail addresses are validated against Ruby's builtin regexp. That one is not very strict, but ensures that we have at least an `@` in it.
* Phone numbers are validated using Phony and are formatted when displayed.