### PR TITLE
Add `federal_state` to schools

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -51,6 +51,7 @@ class SchoolsController < ApplicationController
       :street,
       :zip_code,
       :city,
+      :federal_state,
       :country,
       :homepage_url,
       :email,

--- a/app/views/schools/_form.html.haml
+++ b/app/views/schools/_form.html.haml
@@ -4,6 +4,7 @@
     = f.input :street
     = f.input :zip_code
     = f.input :city
+    = f.input :federal_state
     = f.input :country, priority: ['DE']
     = f.input :homepage_url
     = f.input :email

--- a/app/views/schools/show.html.haml
+++ b/app/views/schools/show.html.haml
@@ -7,6 +7,7 @@
         .flex.flex-col
           %span= @school.street
           %span= @school.city_with_zip_code
+          %span= @school.federal_state
           %span= @school.country_name
 
       = render(list.add(School.human_attribute_name(:homepage_url))) do

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -172,6 +172,7 @@ de:
         street: Strasse und Nummer
         zip_code: Postleitzahl
         city: Ort
+        federal_state: Bundesland / Kanton
         country: Land
         homepage_url: Homepage
         email: E-Mail Adresse

--- a/db/migrate/20221216163532_add_federal_state_to_schools.rb
+++ b/db/migrate/20221216163532_add_federal_state_to_schools.rb
@@ -1,0 +1,5 @@
+class AddFederalStateToSchools < ActiveRecord::Migration[7.0]
+  def change
+    add_column :schools, :federal_state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_16_132621) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_16_163532) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -219,6 +219,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_16_132621) do
     t.string "email"
     t.string "phone_number"
     t.string "fax_number"
+    t.string "federal_state"
   end
 
   create_table "sources", force: :cascade do |t|


### PR DESCRIPTION
Closes #128.

Adds `federal_state` to schools. New form field when creating/editing, and display in the show view of the school.

![image](https://user-images.githubusercontent.com/1394828/208146546-7942b669-6024-42a6-89ce-1b74ca62dd9d.png)

![image](https://user-images.githubusercontent.com/1394828/208146605-38e0de3a-a29b-47b7-8c72-578cd112d1a2.png)
