### PR TITLE
Add paper trail for schools

### DIFF
--- a/app/helpers/version_helper.rb
+++ b/app/helpers/version_helper.rb
@@ -9,8 +9,8 @@ module VersionHelper
     user = User.find_by(id: version.whodunnit)
     username = user&.full_name.presence || user&.email || I18n.t("shared.unknown")
     datetime = I18n.l version.created_at
-    action = I18n.t("words.actions.#{version.event}")
+    action = I18n.t("shared.versions.actions.#{version.event}")
 
-    I18n.t("words.versions.changed_by", action:, username:, datetime:)
+    I18n.t("shared.versions.changed_by", action:, username:, datetime:)
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -3,6 +3,8 @@ class School < ApplicationRecord
   has_many :teachers, through: :teaching_assignments
   has_many :learning_groups
 
+  has_paper_trail
+
   validates_presence_of :name
   validates_presence_of :zip_code
   validates_presence_of :city

--- a/app/views/adjectives/show.html.haml
+++ b/app/views/adjectives/show.html.haml
@@ -27,7 +27,7 @@
 
 = render 'words/general', word: @adjective
 
-= render 'words/versions', word: @adjective
+= render 'shared/versions', model: @adjective
 
 .pagination-with-actions
   = link_to t('actions.edit'), [:edit, @adjective], data: { turbo_frame: '_top' }, class: 'button primary' if can?(:edit, @adjective)

--- a/app/views/nouns/show.html.haml
+++ b/app/views/nouns/show.html.haml
@@ -69,7 +69,7 @@
 
 = render 'words/general', word: @noun
 
-= render 'words/versions', word: @noun
+= render 'shared/versions', model: @noun
 
 .pagination-with-actions
   = link_to t('actions.edit'), [:edit, @noun], data: { turbo_frame: '_top' }, class: 'button primary' if can?(:edit, @noun)

--- a/app/views/schools/show.html.haml
+++ b/app/views/schools/show.html.haml
@@ -47,5 +47,7 @@
     - @school.learning_groups.each do |learning_group|
       .p-4= link_to_if can?(:show, learning_group), learning_group.name, [@school, learning_group]
 
+= render 'shared/versions', model: @school
+
 .pagination-with-actions
   = link_to t('actions.edit'), edit_school_path(@school), class: 'button primary' if can? :edit, @school

--- a/app/views/shared/_versions.html.haml
+++ b/app/views/shared/_versions.html.haml
@@ -1,7 +1,7 @@
-- if can? :read_versions, word
+- if can? :read_versions, model
   = two_column_card t('.title'), '' do
     .flex.flex-col.gap-4
-      - versions = versions_with_changes word.versions
+      - versions = versions_with_changes model.versions
       - if versions.empty?
         = box do
           = t '.no_versions'
@@ -16,7 +16,7 @@
               .mt-2.md:mt-0
                 - version.changeset.except("updated_at").each do |attribute, values|
                   .flex.gap-1.items-center
-                    .font-bold.text-md.mr-2= Word.human_attribute_name(attribute.to_sym)
+                    .font-bold.text-md.mr-2= model.class.human_attribute_name(attribute.to_sym)
                     .flex.gap-1.items-center.flex-wrap{ class: values[0]&.is_a?(Array) ? 'flex-col' : ''}
                       - if values[0]&.is_a? Array
                         .flex.flex-col.gap-1.grow

--- a/app/views/verbs/show.html.haml
+++ b/app/views/verbs/show.html.haml
@@ -128,7 +128,7 @@
 
 = render 'words/general', word: @verb
 
-= render 'words/versions', word: @verb
+= render 'shared/versions', model: @verb
 
 .pagination-with-actions
   = link_to t('actions.edit'), [:edit, @verb], data: { turbo_frame: '_top' }, class: 'button primary' if can?(:edit, @verb)

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -56,14 +56,6 @@ de:
     edit:
       title: Adjektiv bearbeiten
   words:
-    actions:
-      create: Erstellt
-      destroy: Gelöscht
-      update: Bearbeitet
-    versions:
-      title: Änderungshistorie
-      changed_by: '%{action} von %{username} am %{datetime}'
-      no_versions: Dieses Wort wurde noch nicht geändert.
     show:
       general:
         title: Bedeutung
@@ -275,3 +267,12 @@ de:
       move_word_to_next_section: ins nächste Fach schieben
       show_word: Wort anzeigen
       show_actions: Aktionen anzeigen
+  shared:
+    versions:
+      title: Änderungshistorie
+      changed_by: '%{action} von %{username} am %{datetime}'
+      no_versions: Dies wurde noch nicht geändert.
+      actions:
+        create: Erstellt
+        destroy: Gelöscht
+        update: Bearbeitet

--- a/spec/features/nouns_spec.rb
+++ b/spec/features/nouns_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "nouns" do
       end
 
       it "shows change history" do
-        expect(page).to have_content t("words.versions.title")
+        expect(page).to have_content t("shared.versions.title")
       end
     end
   end


### PR DESCRIPTION
Related to #106.

## Changes

* Adds a paper trail to schools. Sorry, I missed that in the last PR.
* Refactors the `versions` partial to be independent of words. That is, we use the same partial to show changes in words and schools.

![image](https://user-images.githubusercontent.com/1394828/208155311-b2cda20a-333f-4e40-929b-5f1575ddb831.png)
