### PR TITLE
Plural search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby "3.1.0"
 
 gem "rails", "~> 7.0.4"
+gem "active_record_extended"
 gem "active_storage_svg_sanitizer"
 gem "bootsnap", require: false
 gem "cancancan"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,9 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_record_extended (3.1.0)
+      activerecord (>= 5.2, < 7.1.0)
+      pg (< 3.0)
     active_storage_svg_sanitizer (0.1.0)
       rails (>= 5.2)
     activejob (7.0.4)
@@ -416,6 +419,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_record_extended
   active_storage_svg_sanitizer
   better_errors
   binding_of_caller

--- a/app/controllers/concerns/word_filter.rb
+++ b/app/controllers/concerns/word_filter.rb
@@ -85,6 +85,8 @@ module WordFilter
       Word.union(
         filter_wordquery("%#{query}%"),
         where("plural ILIKE ?", term),
+        where("comparative ILIKE ?", term),
+        where("superlative ILIKE ?", term),
         filter_cologne_phonetics(query)
       )
     }

--- a/app/controllers/concerns/word_filter.rb
+++ b/app/controllers/concerns/word_filter.rb
@@ -42,6 +42,7 @@ module WordFilter
     filterrific(
       available_filters: [
         :filter_type,
+        :filter_smart,
         :filter_wordstarts,
         :filter_wordends,
         :filter_wordcontains,
@@ -74,6 +75,13 @@ module WordFilter
 
     scope :filter_type, lambda { |type|
       where(type: type.presence || "")
+    }
+
+    scope :filter_smart, lambda { |query|
+      Word.union(
+        filter_wordquery("%#{query}%"),
+        filter_cologne_phonetics(query)
+      )
     }
 
     scope :filter_wordquery, lambda { |query|

--- a/app/controllers/concerns/word_filter.rb
+++ b/app/controllers/concerns/word_filter.rb
@@ -78,8 +78,13 @@ module WordFilter
     }
 
     scope :filter_smart, lambda { |query|
+      return if query.blank?
+
+      term = replace_regex query
+
       Word.union(
         filter_wordquery("%#{query}%"),
+        where("plural ILIKE ?", term),
         filter_cologne_phonetics(query)
       )
     }

--- a/app/views/shared/_filter.html.haml
+++ b/app/views/shared/_filter.html.haml
@@ -3,7 +3,7 @@
     .relative.rounded-md.shadow-sm.mx-2.md:mx-0
       .absolute.inset-y-0.left-0.pl-3.flex.items-center.pointer-events-none
         = heroicon 'magnifying-glass', options: {class: 'text-gray-500 sm:text-sm'}
-      = f.text_field :filter_cologne_phonetics, data: {action: "input->form-submission#search"}, class: 'pl-12 pr-12 bg-gray-50', autofocus: true
+      = f.text_field :filter_smart, data: {action: "input->form-submission#search"}, class: 'pl-12 pr-12 bg-gray-50', autofocus: true
       .absolute.inset-y-0.right-0.flex.items-center
         = link_to reset_filterrific_url, class: 'pr-3 text-gray-500', title: t('filter.reset') do
           = heroicon 'x-mark'

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -362,6 +362,13 @@ RSpec.describe Word do
 
       expect(Noun.filter_smart("kinder")).to match [word]
     end
+
+    it "finds increasing forms of adjectives" do
+      word = create :adjective, name: "gut", comparative: "besser", superlative: "besten"
+
+      expect(Adjective.filter_smart("besser")).to match [word]
+      expect(Adjective.filter_smart("besten")).to match [word]
+    end
   end
 
   describe "#set_consonant_vowel" do

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -349,6 +349,15 @@ RSpec.describe Word do
     end
   end
 
+  describe "#filter_smart" do
+    it "finds exact matches as well as phonetic ones" do
+      word1 = create :noun, name: "Fahrrad"
+      word2 = create :noun, name: "Havarie"
+
+      expect(Noun.filter_smart("var")).to match [word1, word2]
+    end
+  end
+
   describe "#set_consonant_vowel" do
     it "detects vowels and consonants" do
       word = create :noun, name: "Ähre"

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -356,6 +356,12 @@ RSpec.describe Word do
 
       expect(Noun.filter_smart("var")).to match [word1, word2]
     end
+
+    it "finds plural form of noun" do
+      word = create :noun, name: "Kind", plural: "Kinder"
+
+      expect(Noun.filter_smart("kinder")).to match [word]
+    end
   end
 
   describe "#set_consonant_vowel" do


### PR DESCRIPTION
Closes #117.

This is a simple implementation of the requirement in #117. If you search for `kinder`, you'll now find `Kind` as well.

## Changes

* The single filter fields of nouns, verbs and adjectives now use a "smart filter".
* The smart filter searches for different things and then justs `UNION`s them together into search results. It searches in:
  * The base form of the word (aka `name`)
  * The plural form of a noun
  * The comparative or superlative form of an adjective
  * The phonetic representation of the base form

## Caveats

* The power search page is unchanged. Entering a plural form of a noun there won't find anything.
* This is kind of a quick fix. It satisfies the requirement in #117. I'd suggest that we create a general concept about the search first (as in #67) before we invest more time in this.
* There is still no ranking algorithm.