### PR TITLE
Fix flaky spec as order does not matter

### DIFF
--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -354,7 +354,7 @@ RSpec.describe Word do
       word1 = create :noun, name: "Fahrrad"
       word2 = create :noun, name: "Havarie"
 
-      expect(Noun.filter_smart("var")).to match [word1, word2]
+      expect(Noun.filter_smart("var")).to match_array [word1, word2]
     end
 
     it "finds plural form of noun" do


### PR DESCRIPTION
This fixes a spec where the expectation of an array is wrong. `match` is dependent on the order of the items in the array, whereas `match_array` is not. As we don't order it yet, this makes the spec stable.