### PR TITLE
Add email confirmation

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -8,5 +8,11 @@ module Users
         return redirect_to after_sign_out_path_for(resource_name), status: :see_other
       end
     end
+
+    def after_sign_in_path_for(resource)
+      return edit_profile_path if resource.full_name.blank?
+
+      super
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-    :recoverable, :rememberable, :validatable
+    :recoverable, :rememberable, :validatable, :confirmable
 
   has_one_attached :avatar do |attachable|
     attachable.variant :thumb, resize_to_fill: [64, 64]
@@ -46,6 +46,12 @@ class User < ApplicationRecord
 
   def word_in_flashcards?(word)
     flashcard_lists.joins(:words).exists?("words.id": word.id)
+  end
+
+  def active_for_authentication?
+    send_confirmation_instructions if !confirmed? && confirmation_token.blank?
+
+    super
   end
 
   private

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -157,7 +157,7 @@ Devise.setup do |config|
   # without confirming their account.
   # Default is 0.days, meaning the user cannot access the website without
   # confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
+  config.allow_unconfirmed_access_for = 0
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm

--- a/db/migrate/20230203142751_add_confirmable_to_devise.rb
+++ b/db/migrate/20230203142751_add_confirmable_to_devise.rb
@@ -1,0 +1,19 @@
+class AddConfirmableToDevise < ActiveRecord::Migration[7.0]
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string
+
+    add_index  :users, :confirmation_token, unique: true
+  end
+
+  def down
+    remove_index  :users, :confirmation_token
+
+    remove_column :users, :unconfirmed_email
+    remove_column :users, :confirmation_sent_at
+    remove_column :users, :confirmed_at
+    remove_column :users, :confirmation_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_03_102042) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_03_142751) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -325,6 +325,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_03_102042) do
     t.bigint "theme_verb_id"
     t.bigint "theme_adjective_id"
     t.bigint "theme_function_word_id"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["theme_adjective_id"], name: "index_users_on_theme_adjective_id"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     sequence(:email) { |n| "user_#{n}@example.com" }
     password { "secret123" }
     password_confirmation { "secret123" }
+    confirmed_at { 2.days.ago }
   end
 
   factory :admin, class: Admin, parent: :user do

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe "user profile" do
       flow.change_email(new_email:, current_password: user.password)
 
       user.reload
+      user.confirm
       expect(user.email).to eq new_email
     end
 
@@ -114,6 +115,7 @@ RSpec.describe "user profile" do
       flow.change_email(new_email:, current_password: user.password)
 
       user.reload
+      user.confirm
       expect(user.email).to eq new_email
     end
   end

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe "signup" do
   end
 
   it "signs up without role" do
+    expect(ActionMailer::Base.deliveries).to be_empty
+
     expect do
       flow.sign_up(email:, password:)
     end.to change(User, :count).by 1
@@ -19,6 +21,7 @@ RSpec.describe "signup" do
     expect(user.email).to eq email
     expect(user.valid_password?(password)).to be true
     expect(user.role).to eq "Guest"
+    expect(ActionMailer::Base.deliveries).to be_present
   end
 
   it "may fill out profile after sign up" do

--- a/spec/support/flows/signup.rb
+++ b/spec/support/flows/signup.rb
@@ -9,7 +9,14 @@ module Flows
       fill_in User.human_attribute_name(:password), match: :first, with: password
       fill_in User.human_attribute_name(:password_confirmation), with: password
 
-      click_on t("devise.registrations.new.sign_up")
+      expect do
+        click_on t("devise.registrations.new.sign_up")
+      end.to change(User, :count).by 1
+
+      User.find_by(email:).confirm
+
+      visit new_user_session_path
+      Flows::Signin.new.sign_in(email:, password:)
     end
   end
 end


### PR DESCRIPTION
Related to #154.

Add email confirmation:

* New users need to confirm their email address before they can sign in
* Existing users receive a confirmation email address when first accessing the app again. They also can't sign in until they have confirmed their email address.