### PR TITLE
Add generation of user accounts

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -44,7 +44,7 @@
     @apply block text-base font-medium text-gray-700;
   }
 
-  input[type="text"], input[type="email"], input[type="password"], .cm-scroller {
+  input[type="text"], input[type="email"], input[type="password"], input[type="number"], .cm-scroller {
     @apply mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border border-gray-300 rounded-md;
   }
 

--- a/app/controllers/learning_group_memberships_controller.rb
+++ b/app/controllers/learning_group_memberships_controller.rb
@@ -36,6 +36,15 @@ class LearningGroupMembershipsController < ApplicationController
     redirect_to @learning_group_membership.learning_group, notice
   end
 
+  def reset_password
+    @user = @learning_group_membership.user
+
+    head :forbidden unless @user.generated_account?
+
+    @new_password = UserAccountGenerator.new.generate_password
+    @user.update!(password: @new_password)
+  end
+
   private
 
   def learning_group_membership_params

--- a/app/controllers/learning_groups/user_generations_controller.rb
+++ b/app/controllers/learning_groups/user_generations_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module LearningGroups
+  class UserGenerationsController < ApplicationController
+    load_resource :learning_group
+
+    def new
+      authorize! :generate_users, @learning_group
+    end
+
+    def create
+      authorize! :generate_users, @learning_group
+
+      @accounts = UserAccountGenerator.new.generate(amount: user_generation_params[:amount].to_i)
+
+      @accounts.each do |account|
+        user = User.create!(
+          email: account[:email],
+          password: account[:password]
+        )
+
+        user.confirm
+
+        LearningGroupMembership.create!(
+          user:,
+          learning_group: @learning_group,
+          access: "granted"
+        )
+      end
+    end
+
+    private
+
+    def user_generation_params
+      params.require(:user_generation).permit(:amount)
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,7 +21,7 @@ class Ability
 
       can :create_request, LearningGroupMembership
       can %i[crud accept_request reject_request], LearningGroupMembership, learning_group_id: LearningGroup.with_group_admin(user).pluck(:id)
-      can :change_group_admin, LearningGroupMembership, learning_group: LearningGroup.with_group_admin(user)
+      can %i[change_group_admin reset_password], LearningGroupMembership, learning_group: LearningGroup.with_group_admin(user)
 
       can :crud, LearningPlea, learning_group: {user_id: user.id}
       can %i[crud add_word remove_word move_word create_private], List, {user_id: user.id}

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -17,7 +17,7 @@ class Ability
 
       can %i[read new create accept_invitation], LearningGroup
       can %i[read read_users read_lists], LearningGroup, users: {id: user.id}
-      can %i[crud invite read_users read_lists], LearningGroup.with_group_admin(user)
+      can %i[crud invite read_users read_lists generate_users], LearningGroup.with_group_admin(user)
 
       can :create_request, LearningGroupMembership
       can %i[crud accept_request reject_request], LearningGroupMembership, learning_group_id: LearningGroup.with_group_admin(user).pluck(:id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,6 +54,10 @@ class User < ApplicationRecord
     super
   end
 
+  def generated_account?
+    email.ends_with?("@#{Rails.application.config.generated_account_domain}")
+  end
+
   private
 
   def setup_flashcards

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,7 +33,7 @@ class User < ApplicationRecord
   end
 
   def to_s
-    full_name.presence || email
+    full_name.presence || email.gsub("@#{Rails.application.config.generated_account_domain}", "")
   end
 
   def first_flashcard_list
@@ -56,6 +56,10 @@ class User < ApplicationRecord
 
   def generated_account?
     email.ends_with?("@#{Rails.application.config.generated_account_domain}")
+  end
+
+  def may_become_group_admin?(membership)
+    membership.access.granted? && !generated_account?
   end
 
   private

--- a/app/services/user_account_generator.rb
+++ b/app/services/user_account_generator.rb
@@ -21,6 +21,10 @@ class UserAccountGenerator
       .map { generate_account }
   end
 
+  def generate_password
+    generate_random(PASSWORD_CHARACTERS * 12 + SPECIAL_CHARCTERS, length: 12)
+  end
+
   private
 
   def generate_account
@@ -40,9 +44,5 @@ class UserAccountGenerator
 
   def generate_username
     generate_random(USERNAME_CHARACTERS, length: 8)
-  end
-
-  def generate_password
-    generate_random(PASSWORD_CHARACTERS * 12 + SPECIAL_CHARCTERS, length: 12)
   end
 end

--- a/app/services/user_account_generator.rb
+++ b/app/services/user_account_generator.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class UserAccountGenerator
+  USERNAME_CHARACTERS = %w[
+    a b c d e f g h i j k m n p q r s t u v w x y z
+    1 2 3 4 5 6 7 8 9
+  ]
+  PASSWORD_CHARACTERS = %w[
+    a b c d e f g h i j k m n p q r s t u v w x y z
+    1 2 3 4 5 6 7 8 9
+  ]
+  SPECIAL_CHARCTERS = %w[
+    ! " # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \ ] ^ _ { | } ~
+  ]
+  MAX_GENERATION_AMOUNT = 50
+
+  def generate(amount: 10)
+    amount
+      .clamp(0, MAX_GENERATION_AMOUNT)
+      .times
+      .map { generate_account }
+  end
+
+  private
+
+  def generate_account
+    username = generate_username
+    password = generate_password
+
+    {
+      username:,
+      email: "#{username}@#{Rails.application.config.generated_account_domain}",
+      password:
+    }
+  end
+
+  def generate_random(characters, length: 12)
+    SecureRandom.send(:choose, characters, length)
+  end
+
+  def generate_username
+    generate_random(USERNAME_CHARACTERS, length: 8)
+  end
+
+  def generate_password
+    generate_random(PASSWORD_CHARACTERS * 12 + SPECIAL_CHARCTERS, length: 12)
+  end
+end

--- a/app/views/learning_group_memberships/reset_password.html.haml
+++ b/app/views/learning_group_memberships/reset_password.html.haml
@@ -1,0 +1,15 @@
+= title_with_actions t('.title')
+
+= box do
+  = box_content do
+    = t '.introduction'
+
+    .grid.grid-cols-2.mt-4
+      .font-bold= t '.email'
+      .font-bold= t '.password'
+
+      %div= @user.email
+      %div= @new_password
+
+  = box_footer do
+    = link_to t('.back'), learning_group_path(@learning_group), class: 'button primary'

--- a/app/views/learning_groups/show.html.haml
+++ b/app/views/learning_groups/show.html.haml
@@ -32,7 +32,7 @@
               %div
               - if can? :edit, membership
                 .ml-4.flex-shrink-0.flex.flex-wrap.gap-2
-                  - if can?(:change_group_admin, membership) && membership.access.granted?
+                  - if can?(:change_group_admin, membership) && membership.user.may_become_group_admin?(membership)
                     - if membership.role.group_admin?
                       = simple_form_for [@learning_group, membership], method: :patch do |f|
                         = f.input :user, as: :hidden

--- a/app/views/learning_groups/show.html.haml
+++ b/app/views/learning_groups/show.html.haml
@@ -43,6 +43,8 @@
                         = f.input :user, as: :hidden
                         = f.input :role, as: :hidden, input_html: { value: 'group_admin' }
                         = f.submit t('.make_group_admin'), class: 'button outline'
+                  - if can?(:reset_password, membership) && membership.user.generated_account?
+                    = button_to t('.reset_password'), reset_password_learning_group_learning_group_membership_path(@learning_group, membership), method: :patch, class: 'button', data: { turbo: false }
                   - if membership.access.granted?
                     = button_to t('actions.remove'), learning_group_learning_group_membership_path(@learning_group, membership), method: :delete, class: 'button'
                   - else

--- a/app/views/learning_groups/show.html.haml
+++ b/app/views/learning_groups/show.html.haml
@@ -19,9 +19,11 @@
 - if can? :read_users, @learning_group
   = two_column_card User.model_name.human(count: 2), "" do
     = box padding: false do
-      - if can? :create, LearningGroupMembership.new(learning_group: @learning_group)
-        .px-4.py-5.flex.justify-end
+      .px-4.py-5.flex.flex-wrap.gap-2.justify-end
+        - if can? :create, LearningGroupMembership.new(learning_group: @learning_group)
           = link_to t('.assign_user'), new_learning_group_learning_group_membership_path(@learning_group), class: 'button primary'
+        - if can? :generate_users, @learning_group
+          = link_to t('.generate_accounts'), new_learning_group_user_generation_path(@learning_group), class: 'button'
 
       = box_description_list do |list|
         - @learning_group.learning_group_memberships.with_access(:requested, :granted).order(access: 'desc').each do |membership|

--- a/app/views/learning_groups/user_generations/create.html.haml
+++ b/app/views/learning_groups/user_generations/create.html.haml
@@ -1,0 +1,18 @@
+= title_with_actions t('.title')
+
+= box do
+  = box_content do
+    .p-2= t('.introduction')
+
+    .grid.grid-cols-2.my-4
+      .font-bold.p-2= t '.email'
+      .font-bold.p-2= t '.password'
+
+      - @accounts.each.with_index do |account, index|
+        .p-2{ class: index.odd? ? "bg-gray-100" : "" }= account[:email]
+        .p-2{ class: index.odd? ? "bg-gray-100" : "" }= account[:password]
+
+  .print:hidden
+    = box_footer do
+      %a.button{ onClick: "window.print()" }= t('.print')
+      = link_to t('.back'), learning_group_path(@learning_group), class: 'button primary'

--- a/app/views/learning_groups/user_generations/new.html.haml
+++ b/app/views/learning_groups/user_generations/new.html.haml
@@ -1,0 +1,11 @@
+= title_with_actions t('.title')
+
+= box padding: false do
+  = form_tag learning_group_user_generation_path(@learning_group), method: :post, data: { turbo: false } do |f|
+    = box_content do
+      = label_tag 'user_generation[amount]', t('.amount')
+      = number_field_tag 'user_generation[amount]', '', autofocus: true
+
+    = box_footer do
+      = submit_tag t('actions.create')
+      = cancel_button learning_group_path(@learning_group)

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,8 @@ module Wortschule
     config.default_app_namespace = "seite"
 
     config.active_job.queue_adapter = :good_job
+
+    # Generated accounts use the following domain for their email address
+    config.generated_account_domain = "user.wort.schule"
   end
 end

--- a/config/locales/actions.de.yml
+++ b/config/locales/actions.de.yml
@@ -8,6 +8,7 @@ de:
     remove: Entfernen
     copy: Kopieren
     continue: Weiter
+    create: Erstellen
   helpers:
     submit:
       create: Erstellen

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -107,6 +107,12 @@ de:
     new:
       title: Benutzer*in hinzufügen
       assign: Hinzufügen
+    reset_password:
+      title: Passwort zurücksetzen
+      introduction: Das Passwort der unten stehenden Benutzer*in wurde zurückgesetzt.
+      email: E-Mail Adresse
+      password: Neues Passwort
+      back: Zurück zur Lerngruppe
   learning_pleas:
     new:
       title: Wortliste hinzufügen
@@ -207,6 +213,7 @@ de:
       make_group_admin: Zum Gruppenadmin befördern
       remove_group_admin: Gruppenadmin entfernen
       assign_list: Wortliste hinzufügen
+      reset_password: Passwort zurücksetzen
     new:
       title: Neue Lerngruppe
     edit:

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -200,6 +200,7 @@ de:
       new: Neue Lerngruppe
     show:
       assign_user: Benutzer*in hinzufügen
+      generate_accounts: Konten generieren
       request_access: Gruppe beitreten
       accept: Zulassen
       reject: Ablehnen
@@ -221,6 +222,17 @@ de:
       copy: In Zwischenablage kopieren
       copied: Kopiert!
       accepted_html: Du bist der Lerngruppe &laquo;%{name}&raquo; beigetreten.
+    user_generations:
+      new:
+        title: Benutzungskonten generieren
+        amount: Wie viele Benutzungskonten sollen erstellt werden?
+      create:
+        title: Benutzungskonten generieren
+        introduction: Die folgenden Benutzungskonten wurden erstellt. Die Passwörter werden nur dieses eine Mal angezeigt. Bitte kopieren Sie sie oder drucken Sie diese Seite aus.
+        email: E-Mail Adresse
+        password: Passwort
+        print: Drucken
+        back: Zurück zur Lerngruppe
   searches:
     show:
       title: Suchen und Filtern

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,8 @@ Rails.application.routes.draw do
       end
 
       resources :learning_group_memberships, only: %i[new create update destroy] do
+        patch :reset_password, on: :member
+
         scope module: :learning_group_memberships do
           post :requests, to: "requests#create", on: :collection
           post "requests/accept", to: "requests#accept"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
     resources :learning_groups do
       scope module: :learning_groups do
         resource :invitation, only: %i[show create destroy]
+        resource :user_generation
       end
 
       resources :learning_group_memberships, only: %i[new create update destroy] do

--- a/spec/features/user_generation_spec.rb
+++ b/spec/features/user_generation_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe "user account generation" do
+  let(:admin) { create :admin }
+
+  before do
+    login_as admin
+  end
+
+  let!(:learning_group) { create :learning_group }
+
+  it "creates user accounts" do
+    generated_accounts_count = User.all.to_a.count { |user| user.generated_account? }
+
+    visit learning_group_path(learning_group)
+    click_on t("learning_groups.show.generate_accounts")
+
+    fill_in t("learning_groups.user_generations.new.amount"), with: 2
+    expect do
+      click_on t("actions.create")
+    end.to change(User, :count).by(2)
+
+    expect(User.all.to_a.count { |user| user.generated_account? }).to eq generated_accounts_count + 2
+  end
+end


### PR DESCRIPTION
Related to #154

Adds generation of user accounts to a learning group. Also includes resetting of the password for generated accounts.

![screengrab-20230204-1804](https://user-images.githubusercontent.com/1394828/216780078-12b45943-b33a-45b4-a408-174bec3e9d18.gif)
