### PR TITLE
Potentially fix a couple of flaky specs

### DIFF
--- a/app/controllers/concerns/list_addable.rb
+++ b/app/controllers/concerns/list_addable.rb
@@ -6,7 +6,7 @@ module ListAddable
   included do
     def add_to_list
       list = List.accessible_by(current_ability).find(params[:list_id])
-      word_type = params[:filterrific][:filter_type] || params[:controller].singularize.capitalize.clamped(%w[Noun Verb Adjective])
+      word_type = params.dig(:filterrific, :filter_type) || params[:controller].singularize.capitalize.clamped(%w[Noun Verb Adjective])
       @filterrific = initialize_filterrific(
         Word,
         (params[:filterrific] || {}).merge(filter_type: word_type)

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -24,11 +24,7 @@ RSpec.describe "word filter" do
       end
 
       fill_in t("filter.wordstarts"), with: "a"
-
-      # Opening/closing the filter is only necessary because Capybara doesn't
-      # wait for the search to complete
-      click_on t("filter.title")
-      click_on t("filter.title")
+      find_button(t("filter.apply"), visible: false).trigger("click")
 
       expect(page).to have_content "Abfall"
       expect(page).to have_content "Abend"
@@ -50,6 +46,7 @@ RSpec.describe "word filter" do
     before do
       visit search_path
       fill_in t("filter.wordstarts"), with: "ab"
+      find_button(t("filter.apply"), visible: false).trigger("click")
     end
 
     it "filters a specific word type", js: true do
@@ -58,11 +55,7 @@ RSpec.describe "word filter" do
       expect(page).to have_content "abstrakt"
 
       choose t("activerecord.models.noun.one")
-
-      # Opening/closing the filter is only necessary because Capybara doesn't
-      # wait for the search to complete
-      click_on t("filter.title")
-      click_on t("filter.title")
+      find_button(t("filter.apply"), visible: false).trigger("click")
 
       expect(page).not_to have_content "abbauen"
       expect(page).to have_content "Abend"
@@ -86,6 +79,7 @@ RSpec.describe "word filter" do
       login_as user
       visit search_path
       fill_in t("filter.wordstarts"), with: "ab"
+      find_button(t("filter.apply"), visible: false).trigger("click")
     end
 
     it "filters a specific word type", js: true do


### PR DESCRIPTION
Potentially fixes some flaky specs.

The issue is that capybara doesn't wait for the Turbo requests firing while the user types. We now click on the hidden submit button (which exists for screen readers). Hopefully, this makes Capybara aware of the form submission and triggers it to wait accordingly.

The CI run through fine in the first attempt, but that's not really a proof that those specs are not flaky anymore.. :slightly_smiling_face: 

After merging this PR, we can rebase the existing PRs to have some more candidate runs.