### PR TITLE
Add Rubocop rules to support editors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+require: standard
+
+inherit_gem:
+  standard: config/base.yml


### PR DESCRIPTION
This adds a `rubocop.yml` to support Rubocop correctly in editors. Otherwise it uses the default Rubocop rules instead of the ones provided by `standardrb`, which makes editors show a lot of warnings.