### PR TITLE
Replace logo in navigation with text

### DIFF
--- a/app/views/application/_navigation.html.haml
+++ b/app/views/application/_navigation.html.haml
@@ -3,9 +3,8 @@
     .flex.items-center.justify-between.h-16
       .flex.items-center
         .flex-shrink-0
-          .h-10.w-10.flex.items-center.justify-center
-            = link_to root_path do
-              = image_tag 'logo.svg', class: 'h-8 w-8', alt: 'Wort.Schule Logo'
+          .flex.items-center.justify-center
+            = link_to t('navigation.site_title'), root_path, class: 'text-white font-bold text-3xl uppercase'
 
       = render 'desktop_user_menu'
 

--- a/config/locales/navigation.de.yml
+++ b/config/locales/navigation.de.yml
@@ -8,3 +8,4 @@ de:
     special_entries: Spezialeinträge
     learning: Lernen
     miscellaneous: Sonstiges
+    site_title: wort.schule


### PR DESCRIPTION
Related to #170 

Replaces the logo in the navigation with text:

![image](https://user-images.githubusercontent.com/1394828/221344786-fcd860d1-090f-4a30-a512-12bf21eed412.png)
