### PR TITLE
Feature 169: TTS for example sentences

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ To quickly test the application locally without customizing the `docker-compose.
 
 ### Processing
 
-- Processing happens in the background via `app/jobs/tts_job.rb`.
+- Processing happens in the background via `app/jobs/tts_job.rb`. This can be triggeredy manually via `TtsJob.perform_now(word)`.
 - The `good_job` gem handles the job. Start via `bundle exec good_job`
-- There is a `with_tts` flag on the word model, which determines whether an audio attachment should be generated.
+- There is a `with_tts` flag on the word model, which determines whether an audio attachment for both the word itself and it's example sentences should be generated.
 - The audio is generated via Google Cloud Text to Speech API and attached to the word.
 - There is a dedicated log file for the job in `log/tts.log`.
 - The voice is randomly selected from the list in the config file.

--- a/app/jobs/tts_job.rb
+++ b/app/jobs/tts_job.rb
@@ -11,17 +11,25 @@ class TtsJob < ApplicationJob
     @logger = Logger.new(Rails.root.join("log", "tts.log"))
     @logger.info "Starting TTS job"
 
-    generate_audio word
+    generate_audios word
 
     @logger.info "Finished TTS job"
   end
 
-  private def generate_audio(word)
-    @logger.info "Processing word #{word.id} (#{word.name})"
+  private def generate_audios(word)
+    attach word, text(word), "audio.mp3"
 
-    word.audio.attach(
-      io: TtsGenerator.call(text(word)),
-      filename: "audio.mp3",
+    word.example_sentences&.each do |sentence|
+      attach word, sentence, "#{word.slug_for_example_sentence(sentence)}.mp3"
+    end
+  end
+
+  private def attach(word, content, name)
+    @logger.info "Processing audio #{name} (#{content}) to Word ##{word.id}"
+
+    word.audios.attach(
+      io: TtsGenerator.call(content),
+      filename: name,
       content_type: "audio/mp3"
     )
   rescue => e

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -201,9 +201,10 @@ class Word < ApplicationRecord
     self.cologne_phonetics = ColognePhonetics.encode(name)
   end
 
-  # Hooks to react to changes in the with_tts attribute and purge or generate audio attachments.
+  # Hooks to react to changes in the with_tts, name and example_sentences attributes and purge or (re)generate audio
+  # attachments.
   def handle_audio_attachments
-    return true unless saved_change_to_with_tts?
+    return true unless saved_change_to_with_tts? || saved_change_to_example_sentences? || saved_change_to_name?
 
     if with_tts?
       TtsJob.perform_later self

--- a/app/views/nouns/show.html.haml
+++ b/app/views/nouns/show.html.haml
@@ -66,7 +66,9 @@
   = two_column_card t('words.show.example_sentences.title'), t('words.show.example_sentences.description') do
     = box padding: false, class: 'striped' do
       - @noun.example_sentences.each do |sentence|
-        .p-4= sentence
+        .p-4
+          = sentence
+          .align-middle.inline-block.ml-5= render 'words/tts', word: @noun, sentence: sentence
 
 = render 'words/general', word: @noun
 

--- a/app/views/nouns/show.html.haml
+++ b/app/views/nouns/show.html.haml
@@ -66,9 +66,10 @@
   = two_column_card t('words.show.example_sentences.title'), t('words.show.example_sentences.description') do
     = box padding: false, class: 'striped' do
       - @noun.example_sentences.each do |sentence|
-        .p-4
+        .p-4.flex.flex-wrap.justify-between.gap-4.items-center
           = sentence
-          .align-middle.inline-block.ml-5= render 'words/tts', word: @noun, sentence: sentence
+          = render 'words/tts', word: @noun, sentence: sentence
+
 
 = render 'words/general', word: @noun
 

--- a/app/views/words/_tts.html.haml
+++ b/app/views/words/_tts.html.haml
@@ -1,2 +1,4 @@
-- if word&.audio&.attached?
-  %audio(src="#{url_for word.audio}" controls)
+- sentence ||= nil
+- if word&.audios&.attached?
+  - audio = sentence.present? ? word.audio_for_example_sentence(sentence) : word.audio_for_word
+  %audio(src="#{url_for audio}" controls)

--- a/spec/jobs/tts_job_spec.rb
+++ b/spec/jobs/tts_job_spec.rb
@@ -3,8 +3,15 @@
 RSpec.describe TtsJob, type: :job do
   include ActiveJob::TestHelper
 
-  let(:word) { create(:noun, with_tts: with_tts) }
   subject(:job) { described_class.perform_later(word) }
+
+  let(:word) do
+    create(
+      :noun,
+      with_tts: with_tts,
+      example_sentences: ["Not all who wander are lost.", "For even the very wise cannot see all ends."]
+    )
+  end
 
   after do
     clear_enqueued_jobs
@@ -25,6 +32,8 @@ RSpec.describe TtsJob, type: :job do
 
     it "generates the audio" do
       expect(TtsGenerator).to receive(:call).with("#{word.article_definite} #{word.name}").and_return(StringIO.new)
+      expect(TtsGenerator).to receive(:call).with(word.example_sentences.first).and_return(StringIO.new)
+      expect(TtsGenerator).to receive(:call).with(word.example_sentences.last).and_return(StringIO.new)
       perform_enqueued_jobs { job }
     end
   end

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -430,6 +430,30 @@ RSpec.describe Word do
       }.to have_enqueued_job(TtsJob).with(word)
     end
 
+    it "is automatically regenerated when the example sentences or the name of the word changes" do
+      word = create(:noun, name: "Adler", with_tts: true)
+
+      expect {
+        word.update!(name: "Geier")
+      }.to have_enqueued_job(TtsJob).with(word)
+
+      expect {
+        word.update!(example_sentences: ["Beispiel-Satz 1"])
+      }.to have_enqueued_job(TtsJob).with(word)
+
+      expect {
+        word.update!(example_sentences: ["Beispiel-Satz 1", "Beispiel-Satz 2"])
+      }.to have_enqueued_job(TtsJob).with(word)
+    end
+
+    it "is not automatically regenerated when neither the example sentences nor the name of the word changes" do
+      word = create(:noun, name: "Adler", with_tts: true, example_sentences: ["Beispiel-Satz 1"])
+
+      expect {
+        word.update!(plural: "Adlers")
+      }.not_to have_enqueued_job(TtsJob).with(word)
+    end
+
     it "is automatically removed when with_tts is set to false" do
       word = create(:noun, name: "Adler")
       word.audios.attach(fixture_file_upload("audio.mp3", "audio/mpeg"))

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -423,7 +423,7 @@ RSpec.describe Word do
   describe "audio attachment" do
     it "is automatically generated when with_tts is set to true" do
       word = create(:noun, name: "Adler", with_tts: false)
-      expect(word.audio.attached?).to be false
+      expect(word.audios.attached?).to be false
 
       expect {
         word.update!(with_tts: true)
@@ -432,13 +432,13 @@ RSpec.describe Word do
 
     it "is automatically removed when with_tts is set to false" do
       word = create(:noun, name: "Adler")
-      word.audio.attach(fixture_file_upload("word.mp3", "audio/mpeg"))
+      word.audios.attach(fixture_file_upload("audio.mp3", "audio/mpeg"))
       word.save!
 
-      expect(word.audio.attached?).to be true
+      expect(word.audios.attached?).to be true
 
       word.update!(with_tts: false)
-      expect(word.audio.attached?).to be false
+      expect(word.audios.attached?).to be false
     end
   end
 end

--- a/spec/support/tts.rb
+++ b/spec/support/tts.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples "TTS" do |klass|
 
   context "when audio is attached" do
     it "displays the audio player" do
-      word.audio.attach(fixture_file_upload("word.mp3", "audio/mpeg"))
+      word.audios.attach(fixture_file_upload("audio.mp3", "audio/mpeg"))
 
       visit send("#{klass.model_name.singular}_path", word)
       expect(page).to have_selector("audio")


### PR DESCRIPTION
- Adds a hint to the README.md how to manually trigger a TTS Job for a word model.
- Adds a mention for example sentences to the README.md
- Adds the TTS generation for the example sentences to the TtsJob
- Refactoring to keep TtsJob DRY
- Extends the word model to have multiple audio files in a backwards compatible way
- Adds some helper methods to the word model to work with the audio attachments
- Extends the tts partial to support the example sentences
- Adds the tts partial to the example sentences of nouns (didn't found that for other words types?)
- Extends the RSpec for the TtsJob to cover example sentences

See #169 