### PR TITLE
Search results | Design and breakpoints

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -5,6 +5,10 @@
 @tailwind utilities;
 
 @layer components {
+  .content {
+    @apply max-w-7xl mx-auto py-6 sm:px-6 lg:px-8;
+  }
+
   h1 {
     @apply mt-6 text-3xl font-extrabold text-gray-900 ml-4 md:ml-0;
   }
@@ -71,7 +75,7 @@
   }
 
   .button {
-    @apply md:inline-block md:w-auto relative w-full flex justify-center py-2 px-4 border border-gray-400 text-sm font-medium rounded-md text-gray-600 bg-white hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400;
+    @apply md:inline-block md:w-auto relative w-full flex justify-center py-2 px-4 border-2 border-primary text-sm rounded-3xl text-primary bg-transparent hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400;
   }
 
   .button.danger {

--- a/app/components/omni_search_field_component.html.haml
+++ b/app/components/omni_search_field_component.html.haml
@@ -1,10 +1,10 @@
-.relative.rounded-md.shadow-sm.mx-2.md:mx-0
+.relative.rounded-full.shadow.mx-2.md:mx-0
   .absolute.inset-y-0.left-0.pl-3.flex.items-center.pointer-events-none
     = heroicon 'magnifying-glass', options: {class: 'text-gray-500 sm:text-sm'}
-  = form.text_field :filter_home, data: input_data_attribute, class: 'pl-12 pr-12 bg-gray-50', autofocus: true, autocomplete: :off
+  = form.text_field :filter_home, data: input_data_attribute, class: 'pl-12 pr-12 bg-gray-50 !rounded-full', autofocus: true, autocomplete: :off
   .absolute.inset-y-0.right-0.flex.items-center
     = link_to reset_filterrific_url, class: 'pr-3 text-gray-500', title: t('filter.reset') do
       = heroicon 'x-mark'
-    - unless on_search_page?
-      = link_to '#', class: 'pr-3 text-gray-500', title: t('.show_x_results', count: words.total_count), data: {action: 'click->home-search#goToSearchResults'} do
-        = heroicon 'arrow-right'
+
+    = link_to '#', class: 'p-3 text-white bg-primary rounded-full', title: t('.show_x_results', count: words.total_count), data: {action: 'click->home-search#goToSearchResults'} do
+      = heroicon 'arrow-right'

--- a/app/components/word_panel_component.html.haml
+++ b/app/components/word_panel_component.html.haml
@@ -7,8 +7,8 @@
           .text-xl.font-bold= word.name
         .uppercase.text-xs.font-light.mt-3= word.model_name.human
 
-      .p-1.pr-4
+      .p-1.pr-4.flex.items-center.object-cover
         - if word.image.attached?
-          = image_tag word.image.variant(:thumb), class: 'w-24 h-24'
+          = image_tag word.image.variant(:thumb), class: 'w-24 h-full object-cover'
         - else
           .w-24.h-24

--- a/app/components/word_panel_component.html.haml
+++ b/app/components/word_panel_component.html.haml
@@ -1,5 +1,5 @@
 = link_to word, data: { turbo_frame: '_top' }, id: dom_id(word) do
-  = box padding: false, class: 'h-full overflow-hidden' do
+  = box padding: false, class: 'h-full' do
     .flex.justify-between.h-full
       .px-4.py-5.sm:px-6
         .flex.items-baseline.gap-1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,20 @@ class ApplicationController < ActionController::Base
   before_action :set_paper_trail_whodunnit
 
   helper_method :page_title
+  helper_method :background_color
+  helper_method :full_width?
 
   private
 
   def page_title
     ""
+  end
+
+  def background_color
+    "bg-gray-100"
+  end
+
+  def full_width?
+    false
   end
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -33,4 +33,12 @@ class SearchesController < PublicController
       (params[:filterrific] || {}).merge(filter_type: word_type)
     ).find.count
   end
+
+  def background_color
+    "bg-white"
+  end
+
+  def full_width?
+    true
+  end
 end

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -14,7 +14,7 @@ module ComponentsHelper
 
     classes += padding ? " px-4 py-5 sm:px-6" : ""
 
-    content_tag "div", options.merge(class: "box bg-white shadow rounded-3xl #{classes}") do
+    content_tag "div", options.merge(class: "box bg-white overflow-hidden border-2 border-gray-border rounded-3xl #{classes}") do
       yield
     end
   end

--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -7,7 +7,7 @@ module FilterHelper
 
     return input_field if inline
 
-    content_tag :div, class: "input" do
+    content_tag :div, class: "input grow" do
       concat form.label form_attribute, I18n.t("filter.#{attribute}")
       concat input_field
     end

--- a/app/views/filters/_form.html.haml
+++ b/app/views/filters/_form.html.haml
@@ -1,4 +1,4 @@
-= box class: 'ci-filter' do
+.ci-filter.p-5.bg-gray-background-highlight
   .flex.justify-center
     = link_to url_for(request.params.merge(is_filter_open: !@is_filter_open)), class: 'flex mb-6 button items-center gap-1' do
       = heroicon 'x-mark'

--- a/app/views/homes/_search_form.html.haml
+++ b/app/views/homes/_search_form.html.haml
@@ -1,5 +1,6 @@
 .mt-6
   = form_for_filterrific @filterrific, html: { data: { turbo_frame: 'words', turbo_action: 'advance', controller: 'form-submission home-search', 'home-search-path-value': search_path } } do |f|
-    = render OmniSearchFieldComponent.new(form: f, words: @words, on_search_page: false)
+    .mx-auto(class="max-w-[50vw]")
+      = render OmniSearchFieldComponent.new(form: f, words: @words, on_search_page: false)
 
     .sr-only= button_tag t('filter.apply'), type: 'submit', title: t('filter.apply')

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html.h-full.bg-gray-100
+%html.h-full(class=background_color)
   %head
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     - app_name = "wort.schule"
@@ -32,7 +32,7 @@
                 = message
 
         %main
-          .max-w-7xl.mx-auto.py-6.sm:px-6.lg:px-8
+          %div{ class: full_width? ? '' : 'content' }
             = yield
 
       = render 'footer'

--- a/app/views/searches/show.html.haml
+++ b/app/views/searches/show.html.haml
@@ -31,10 +31,10 @@
         = f.label :filter_type, t('filter.results.function_words', count: @counts[:function_words]), value: 'FunctionWord'
 
   .bg-gray-background.border-t.border-gray-border
-    .pt-0.flex.flex-col.xl:flex-row
-      %div(class="xl:max-w-[30vh] #{@is_filter_open ? '' : 'hidden'}")
+    .pt-0.flex.flex-col.md:flex-row
+      %div(class="md:max-w-[40vh] #{@is_filter_open ? '' : 'hidden'}")
         = render 'filters/form', f:
-      .p-6.grow
+      .p-6.pt-0.grow
         = render 'words/index', words: @words
 
 .content

--- a/app/views/searches/show.html.haml
+++ b/app/views/searches/show.html.haml
@@ -1,37 +1,42 @@
-%h1= t '.title'
+.content
+  %h1= t '.title'
 
 = form_for_filterrific @filterrific, html: { data: { turbo_frame: 'words_filter', turbo_action: 'advance', controller: 'form-submission filter' } } do |f|
   = hidden_field_tag :is_filter_open, params[:is_filter_open]
-  .flex.flex-wrap.gap-4
-    .flex-grow
-      = render OmniSearchFieldComponent.new(form: f, words: @words, on_search_page: true)
-    - unless @is_filter_open
-      = link_to url_for(request.params.merge(is_filter_open: !@is_filter_open)), class: 'flex button items-center gap-1' do
-        = heroicon 'sparkles'
-        = t('filter.open')
 
-  .px-6.mt-12.flex.flex-col.justify-center.md:flex-row.gap-2.md:gap-8.tabbed-radio-buttons
-    .flex.items-center.gap-2
-      = f.radio_button :filter_type, '', data: {action: "input->form-submission#search click->filter#hideAll"}
-      = f.label :filter_type, t('filter.results.all', count: @counts[:all]), value: ''
-    .flex.items-center.gap-2
-      = f.radio_button :filter_type, 'Noun', data: {action: "input->form-submission#search click->filter#showNoun"}
-      = f.label :filter_type, t('filter.results.nouns', count: @counts[:nouns]), value: 'Noun'
-    .flex.items-center.gap-2
-      = f.radio_button :filter_type, 'Verb', data: {action: "input->form-submission#search click->filter#showVerb"}
-      = f.label :filter_type, t('filter.results.verbs', count: @counts[:verbs]), value: 'Verb'
-    .flex.items-center.gap-2
-      = f.radio_button :filter_type, 'Adjective', data: {action: "input->form-submission#search click->filter#showAdjective"}
-      = f.label :filter_type, t('filter.results.adjectives', count: @counts[:adjectives]), value: 'Adjective'
-    .flex.items-center.gap-2
-      = f.radio_button :filter_type, 'FunctionWord', data: {action: "input->form-submission#search click->filter#showFunctionWord"}
-      = f.label :filter_type, t('filter.results.function_words', count: @counts[:function_words]), value: 'FunctionWord'
+  .content.pb-0
+    .flex.flex-wrap.gap-4
+      .flex-grow
+        = render OmniSearchFieldComponent.new(form: f, words: @words, on_search_page: true)
+      - unless @is_filter_open
+        = link_to url_for(request.params.merge(is_filter_open: !@is_filter_open)), class: 'flex button items-center gap-1' do
+          = heroicon 'sparkles'
+          = t('filter.open')
 
-  .flex.flex-col.xl:flex-row
-    .mt-6(class="xl:max-w-[30vh] #{@is_filter_open ? '' : 'hidden'}")
-      = render 'filters/form', f:
-    .p-6.grow
-      = render 'words/index', words: @words
+    .px-6.mt-12.flex.flex-col.justify-center.md:flex-row.gap-2.md:gap-8.tabbed-radio-buttons
+      .flex.items-center.gap-2
+        = f.radio_button :filter_type, '', data: {action: "input->form-submission#search click->filter#hideAll"}
+        = f.label :filter_type, t('filter.results.all', count: @counts[:all]), value: ''
+      .flex.items-center.gap-2
+        = f.radio_button :filter_type, 'Noun', data: {action: "input->form-submission#search click->filter#showNoun"}
+        = f.label :filter_type, t('filter.results.nouns', count: @counts[:nouns]), value: 'Noun'
+      .flex.items-center.gap-2
+        = f.radio_button :filter_type, 'Verb', data: {action: "input->form-submission#search click->filter#showVerb"}
+        = f.label :filter_type, t('filter.results.verbs', count: @counts[:verbs]), value: 'Verb'
+      .flex.items-center.gap-2
+        = f.radio_button :filter_type, 'Adjective', data: {action: "input->form-submission#search click->filter#showAdjective"}
+        = f.label :filter_type, t('filter.results.adjectives', count: @counts[:adjectives]), value: 'Adjective'
+      .flex.items-center.gap-2
+        = f.radio_button :filter_type, 'FunctionWord', data: {action: "input->form-submission#search click->filter#showFunctionWord"}
+        = f.label :filter_type, t('filter.results.function_words', count: @counts[:function_words]), value: 'FunctionWord'
 
-= turbo_frame_tag :add_words_to_list do
-  = render 'filters/add_to_list'
+  .bg-gray-background.border-t.border-gray-border
+    .pt-0.flex.flex-col.xl:flex-row
+      %div(class="xl:max-w-[30vh] #{@is_filter_open ? '' : 'hidden'}")
+        = render 'filters/form', f:
+      .p-6.grow
+        = render 'words/index', words: @words
+
+.content
+  = turbo_frame_tag :add_words_to_list do
+    = render 'filters/add_to_list'

--- a/app/views/searches/show.html.haml
+++ b/app/views/searches/show.html.haml
@@ -1,6 +1,3 @@
-.content
-  %h1= t '.title'
-
 = form_for_filterrific @filterrific, html: { data: { turbo_frame: 'words_filter', turbo_action: 'advance', controller: 'form-submission filter' } } do |f|
   = hidden_field_tag :is_filter_open, params[:is_filter_open]
 

--- a/app/views/searches/show.html.haml
+++ b/app/views/searches/show.html.haml
@@ -5,13 +5,14 @@
   = hidden_field_tag :is_filter_open, params[:is_filter_open]
 
   .content.pb-0
-    .flex.flex-wrap.gap-4
-      .flex-grow
-        = render OmniSearchFieldComponent.new(form: f, words: @words, on_search_page: true)
-      - unless @is_filter_open
-        = link_to url_for(request.params.merge(is_filter_open: !@is_filter_open)), class: 'flex button items-center gap-1' do
-          = heroicon 'sparkles'
-          = t('filter.open')
+    .my-10.mx-auto(class="max-w-[50vw]")
+      .flex.flex-wrap.gap-4
+        .flex-grow
+          = render OmniSearchFieldComponent.new(form: f, words: @words, on_search_page: true)
+        - unless @is_filter_open
+          = link_to url_for(request.params.merge(is_filter_open: !@is_filter_open)), class: 'flex button items-center gap-1' do
+            = heroicon 'sparkles'
+            = t('filter.open')
 
     .px-6.mt-12.flex.flex-col.justify-center.md:flex-row.gap-2.md:gap-8.tabbed-radio-buttons
       .flex.items-center.gap-2

--- a/app/views/words/_index.html.haml
+++ b/app/views/words/_index.html.haml
@@ -1,5 +1,7 @@
 = turbo_frame_tag 'words' do
-  = index_grid do
+  - columns = @is_filter_open ? 'grid-cols-1 lg:grid-cols-2 xl:grid-cols-3' : 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
+
+  .grid.my-6.gap-4(class=columns)
     - words.each do |word|
       = render word
 

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -240,9 +240,6 @@ de:
         password: Passwort
         print: Drucken
         back: Zurück zur Lerngruppe
-  searches:
-    show:
-      title: Suchen und Filtern
   themes:
     index:
       new: Neue Wortkarten-Variante

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -22,7 +22,10 @@ module.exports = {
       colors: {
         primary: '#2A7BF7',
         'primary-hover': '#4D91F7',
-        'primary-selected': '#1E6CE3'
+        'primary-selected': '#1E6CE3',
+        'gray-background': '#F3F4F6',
+        'gray-border': '#E6E6E7',
+        'gray-background-highlight': '#E6E6E6'
       }
     },
   },


### PR DESCRIPTION
Closes #171 and #188.

![image](https://user-images.githubusercontent.com/1394828/221374102-54a5154a-5b7b-44d5-8906-a9c406280aa9.png)

## Changes

* Adapt search results page to better fit the new design
* Change breakpoints for search results. These depend on whether the filter is open or not. The GIFs are not completely up to date regarding design, but the grid and layout did not change.

  With an open filter:

  ![screengrab-20230225-1914](https://user-images.githubusercontent.com/1394828/221373291-b0b3f5d2-1636-447f-bbf0-18e09a408082.gif)

  Without the filter:

  ![screengrab-20230225-1920](https://user-images.githubusercontent.com/1394828/221373330-599d1316-d288-417b-9a73-3f482157e5e1.gif)