### PR TITLE
New search | Hide logo during search

### DIFF
--- a/app/components/omni_search_field_component.rb
+++ b/app/components/omni_search_field_component.rb
@@ -22,7 +22,7 @@ class OmniSearchFieldComponent < ViewComponent::Base
       }
     else
       {
-        action: "input->form-submission#search keydown->home-search#input",
+        action: "input->form-submission#search keyup->home-search#input",
         "home-search-target": "input"
       }
     end

--- a/app/javascript/controllers/home_search_controller.js
+++ b/app/javascript/controllers/home_search_controller.js
@@ -3,17 +3,31 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="home-search"
 export default class extends Controller {
   static targets = [
-    "input"
+    "input",
+    "logo"
   ]
 
   static values = {
     path: String
   }
 
+  connect() {
+    this.updateLogoVisibility(false)
+  }
+
   input(event) {
     if (event.key === 'Enter') {
       this.goToSearchResults()
+      return
     }
+
+    this.updateLogoVisibility(true)
+  }
+
+  updateLogoVisibility(reposition) {
+    var hasQuery = this.inputTarget.value.length > 0
+    this.logoTarget.style.display = hasQuery ? 'none' : 'block'
+    if(reposition) this.inputTarget.scrollIntoView()
   }
 
   goToSearchResults() {

--- a/app/views/homes/_search_form.html.haml
+++ b/app/views/homes/_search_form.html.haml
@@ -1,5 +1,5 @@
 .mt-6
-  = form_for_filterrific @filterrific, html: { data: { turbo_frame: 'words', turbo_action: 'advance', controller: 'form-submission home-search', 'home-search-path-value': search_path } } do |f|
+  = form_for_filterrific @filterrific, html: { data: { turbo_frame: 'words', turbo_action: 'advance', controller: 'form-submission', 'home-search-path-value': search_path } } do |f|
     .mx-auto(class="md:max-w-[50vw]")
       = render OmniSearchFieldComponent.new(form: f, words: @words, on_search_page: false)
 

--- a/app/views/homes/show.html.haml
+++ b/app/views/homes/show.html.haml
@@ -1,13 +1,13 @@
-%h1 
-.flex.justify-center
-  = image_tag 'logo_transparent.svg', alt: '', class: 'max-w-md'
+%div(data-controller="home-search")
+  .flex.justify-center
+    = image_tag 'logo_transparent.svg', alt: '', class: 'max-w-md', 'data-home-search-target': 'logo'
 
-= render 'search_form'
+  = render 'search_form'
 
-= turbo_frame_tag 'words' do
-  - if @words.present?
-    .bg-white.pt-6.rounded-3xl.rounded-tl-none.rounded-tr-none.mx-auto(class="md:max-w-[50vw]" style="margin-top: -0.5rem")
-      = render partial: 'search_result', collection: @words, as: :word
+  = turbo_frame_tag 'words' do
+    - if @words.present?
+      .bg-white.pt-4.rounded-3xl.rounded-tl-none.rounded-tr-none.mx-auto(class="md:max-w-[50vw]" style="margin-top: -0.5rem")
+        = render partial: 'search_result', collection: @words, as: :word
 
-      .p-6.text-center
-        = link_to t('.show_x_results', count: @words.total_count), search_path(request.params), 'data-turbo-frame': '_top', class: 'button'
+        .p-6.text-center
+          = link_to t('.show_x_results', count: @words.total_count), search_path(request.params), 'data-turbo-frame': '_top', class: 'button'


### PR DESCRIPTION
Closes #170.

This hides the logo when the user types in the search field on the homepage.

Originally in #170 this was supposed to only be done on mobiles. However, during testing I didn't dislike the effect on the desktop, especially on smaller laptops. @wintermeyer What do you think? Shall we limit the effect only to mobiles?

![screengrab-20230225-2250](https://user-images.githubusercontent.com/1394828/221381158-04b9bc17-b585-4e0d-8f44-1b74ad9eae1c.gif)
