### PR TITLE
Fix word type filter on mobile

### DIFF
--- a/app/views/searches/_mobile_word_type_filter.html.haml
+++ b/app/views/searches/_mobile_word_type_filter.html.haml
@@ -17,6 +17,6 @@
 
         .absolute.right-0.mt-2.hidden.z-50(data-dropdown-target="menu")
           .shadow.rounded-md.border.overflow-hidden.bg-white
-            = link_to t('filter.results.all_results'), url_for(request.params.merge('filterrific[filter_type]': '')), 'data-action': 'click->dropdown#toggle', class: 'no-underline block px-8 py-3 hover:text-primary'
+            = link_to t('filter.results.all_results'), url_for(request.params.deep_merge('filterrific': {filter_type: ''})), 'data-action': 'click->dropdown#toggle', class: 'no-underline block px-8 py-3 hover:text-primary'
             - [Noun, Verb, Adjective, FunctionWord].each do |type|
-              = link_to type.model_name.human(count: 2), url_for(request.params.merge('filterrific[filter_type]': type.model_name.name)), 'data-action': 'click->dropdown#toggle', class: 'no-underline block px-8 py-3 hover:text-primary'
+              = link_to type.model_name.human(count: 2), url_for(request.params.deep_merge('filterrific': {filter_type: type.model_name.name})), 'data-action': 'click->dropdown#toggle', class: 'no-underline block px-8 py-3 hover:text-primary'


### PR DESCRIPTION
Closes #196

The problem was that using the normal `merge` the param `filterrific[word_type]` was not correctly merged and hence appeared twice in the URL.