### PR TITLE
Change to trim whitespaces

### DIFF
--- a/app/controllers/concerns/word_filter.rb
+++ b/app/controllers/concerns/word_filter.rb
@@ -5,9 +5,13 @@ module WordFilter
 
   class_methods do
     def replace_regex(query)
-      query
+      squeeze query
         .tr("*", "%")
         .tr("?", "_")
+    end
+
+    def squeeze(query)
+      query.squeeze(" ").strip
     end
 
     def filter_with_conjunction(attribute, options)
@@ -81,6 +85,7 @@ module WordFilter
     scope :filter_smart, lambda { |query|
       return if query.blank?
 
+      query = squeeze query
       term = replace_regex query
 
       Word.union(
@@ -95,6 +100,7 @@ module WordFilter
     scope :filter_home, lambda { |query|
       return if query.blank?
 
+      query = squeeze query
       term = replace_regex query
 
       # The additional query for `id` is necessary, because `union` does not
@@ -114,6 +120,7 @@ module WordFilter
     scope :filter_wordquery, lambda { |query|
       return if query.blank?
 
+      query = squeeze query
       term = replace_regex query
       where("name ILIKE ?", term)
     }
@@ -133,6 +140,7 @@ module WordFilter
     scope :filter_syllablescontains, lambda { |query|
       return if query.blank?
 
+      query = squeeze query
       query = replace_regex query
       syllables_terms = [
         "#{query}-%",
@@ -158,12 +166,14 @@ module WordFilter
     scope :filter_cologne_phonetics, lambda { |query|
       return if query.blank?
 
+      query = squeeze query
       where("cologne_phonetics ILIKE ?", "#{ColognePhonetics.encode(query)}%")
     }
 
     scope :filter_letters, lambda { |query|
       return if query.blank?
 
+      query = squeeze query
       letters = query
         .gsub(/[^[:alpha:]]/, "")
         .chars

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -97,6 +97,20 @@ RSpec.describe Word do
     end
   end
 
+  describe "#filter_home" do
+    it "filters words" do
+      word = create :noun, name: "Ähre"
+      expect(Noun.filter_home("ähre")).to include word
+    end
+
+    it "ignores whitespaces" do
+      word1 = create :noun, name: "Ähre"
+      word2 = create :noun, name: "American Football"
+      expect(Noun.filter_home("ähre ")).to include word1
+      expect(Noun.filter_home("american  football ")).to include word2
+    end
+  end
+
   describe "#filter_letters" do
     it "matches umlauts" do
       word = create :noun, name: "Ähre"


### PR DESCRIPTION
Closes #208

## Changes

* Removes whitespaces from beginning and end of the search query
* Coalesces whitespaces within the word to one. So when searching for `american   football`, we will search the database for `american football`.