### PR TITLE
Fix cursor not moving on Turbo updates

### DIFF
--- a/app/components/omni_search_field_component.html.haml
+++ b/app/components/omni_search_field_component.html.haml
@@ -1,7 +1,7 @@
 .relative.rounded-full.shadow.mx-2.md:mx-0
   .absolute.inset-y-0.left-0.pl-3.flex.items-center.pointer-events-none
     = heroicon 'magnifying-glass', options: {class: 'text-gray-500 sm:text-sm'}
-  = form.text_field :filter_home, data: input_data_attribute, class: 'pl-12 pr-12 bg-gray-50 !rounded-full', autofocus: true, autocomplete: :off
+  = form.text_field :filter_home, data: input_data_attribute, class: 'pl-12 pr-12 bg-gray-50 !rounded-full', autofocus: true, autocomplete: :off, 'data-turbo-permanent': true
   .absolute.inset-y-0.right-0.flex.items-center
     = link_to reset_filterrific_url, class: 'pr-3 text-gray-500', title: t('filter.reset') do
       = heroicon 'x-mark'

--- a/app/components/omni_search_field_component.rb
+++ b/app/components/omni_search_field_component.rb
@@ -16,15 +16,9 @@ class OmniSearchFieldComponent < ViewComponent::Base
   end
 
   def input_data_attribute
-    if on_search_page?
-      {
-        action: "input->form-submission#search"
-      }
-    else
-      {
-        action: "input->form-submission#search keyup->home-search#input",
-        "home-search-target": "input"
-      }
-    end
+    {
+      action: "input->form-submission#search keyup->home-search#input",
+      "home-search-target": "input"
+    }
   end
 end

--- a/app/views/homes/_search_form.html.haml
+++ b/app/views/homes/_search_form.html.haml
@@ -1,5 +1,5 @@
 .mt-6
-  = form_for_filterrific @filterrific, html: { data: { turbo_frame: 'words', turbo_action: 'advance', controller: 'form-submission', 'home-search-path-value': search_path } } do |f|
+  = form_for_filterrific @filterrific, html: { data: { turbo_frame: 'words', turbo_action: 'advance', controller: 'form-submission' } } do |f|
     .mx-auto(class="md:max-w-[50vw]")
       = render OmniSearchFieldComponent.new(form: f, words: @words, on_search_page: false)
 

--- a/app/views/homes/show.html.haml
+++ b/app/views/homes/show.html.haml
@@ -1,4 +1,4 @@
-%div(data-controller="home-search")
+%div(data-controller="home-search" data-home-search-path-value=search_path)
   .flex.justify-center
     = image_tag 'logo_transparent.svg', alt: '', class: 'max-w-md', 'data-home-search-target': 'logo'
 


### PR DESCRIPTION
Closes #195

Ensures the cursor doesn't jump in the search field while typing.

![screengrab-20230227-1908](https://user-images.githubusercontent.com/1394828/221647396-e001ce51-916d-41eb-a7cb-0c0c4e011f06.gif)
