### PR TITLE
Mobile | Logo removal on homepage

### DIFF
--- a/app/javascript/controllers/home_search_controller.js
+++ b/app/javascript/controllers/home_search_controller.js
@@ -29,7 +29,7 @@ export default class extends Controller {
 
     var hasQuery = this.inputTarget.value.length > 0
     this.logoTarget.style.display = hasQuery ? 'none' : 'block'
-    if(reposition) this.inputTarget.scrollIntoView()
+    if(reposition) this.inputTarget.scrollIntoView({ behavior: 'smooth' })
   }
 
   goToSearchResults() {

--- a/app/javascript/controllers/home_search_controller.js
+++ b/app/javascript/controllers/home_search_controller.js
@@ -25,6 +25,8 @@ export default class extends Controller {
   }
 
   updateLogoVisibility(reposition) {
+    if(window.innerWidth > 768) return
+
     var hasQuery = this.inputTarget.value.length > 0
     this.logoTarget.style.display = hasQuery ? 'none' : 'block'
     if(reposition) this.inputTarget.scrollIntoView()

--- a/app/views/homes/show.html.haml
+++ b/app/views/homes/show.html.haml
@@ -6,7 +6,7 @@
 
   = turbo_frame_tag 'words' do
     - if @words.present?
-      .bg-white.pt-4.rounded-3xl.rounded-tl-none.rounded-tr-none.mx-auto(class="md:max-w-[50vw]" style="margin-top: -0.5rem")
+      .bg-white.pt-4.rounded-3xl.rounded-tl-none.rounded-tr-none.mx-2.md:mx-auto(class="md:max-w-[50vw]" style="margin-top: -0.5rem")
         = render partial: 'search_result', collection: @words, as: :word
 
         .p-6.text-center


### PR DESCRIPTION
Closes #193 

Changes the logo on the homepage to only be removed on mobile devices.

Also instructed browsers to scroll smoothly, for those which support it.

[`scrollIntoView()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) is used for the scrolling, which doesn't support much customizations. We do have to use it though as without it the input field is outside of the view to the top.

As an alternative, what about showing the input field at the top on mobiles from the beginning? The search results would then show above the logo.

![image](https://user-images.githubusercontent.com/1394828/221690093-41f20e0b-620f-4466-96f0-f3152a62bcc2.png)
