### PR TITLE
Fix empty search field

### DIFF
--- a/app/components/omni_search_field_component.html.haml
+++ b/app/components/omni_search_field_component.html.haml
@@ -1,7 +1,7 @@
 .relative.rounded-full.shadow.mx-2.md:mx-0
   .absolute.inset-y-0.left-0.pl-3.flex.items-center.pointer-events-none
     = heroicon 'magnifying-glass', options: {class: 'text-gray-500 sm:text-sm'}
-  = form.text_field :filter_home, data: input_data_attribute, class: 'pl-12 pr-12 bg-gray-50 !rounded-full', autofocus: true, autocomplete: :off, 'data-turbo-permanent': true
+  = form.text_field :filter_home, data: input_data_attribute, class: 'pl-12 pr-12 bg-gray-50 !rounded-full', autofocus: true, autocomplete: :off, 'data-turbo-permanent': true, 'data-controller': 'reset-search'
   .absolute.inset-y-0.right-0.flex.items-center
     = link_to reset_filterrific_url, class: 'pr-3 text-gray-500', title: t('filter.reset') do
       = heroicon 'x-mark'

--- a/app/javascript/controllers/reset_search_controller.js
+++ b/app/javascript/controllers/reset_search_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="reset-search"
+export default class extends Controller {
+  connect() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const query = urlParams.get('filterrific[filter_home]')
+    this.element.value = query
+  }
+}


### PR DESCRIPTION
Closes #198

This fixes the search field to contain arbitrary old values.

The cause of this is `data-turbo-permanent` which makes the element sticky on the page. It will never be recreated when changing the page. This is great so that the cursor stays where it is. If we were to recreate the element, the cursor jumps to the beginning (happens while the user is typing).

The amazing thing is that those arbitrary values even survive hard refreshes of the browser. I assume that Turbo is caching the element somewhere. We therefore have to reset the value manually.

Before this change I was able to reproduce the issue with:

1. Enter something on the homepage
2. Hit enter to go to the search results page
3. Click on the logo on the top left
4. No results are shown. The input field still shows the old value.

After this change, this behavior is fixed. The input field is now empty.