### PR TITLE
Add space between article and noun

### DIFF
--- a/app/views/homes/_search_result.html.haml
+++ b/app/views/homes/_search_result.html.haml
@@ -5,9 +5,9 @@
     - else
       %div
 
-    .py-2.flex.gap-1
+    .py-2
       - if word.is_a? Noun
-        = word.article_definite
-      .font-bold= word.name
+        %span= "#{word.article_definite} "
+      %span.font-bold= word.name
 
   .uppercase.text-xs.py-2= word.model_name.human


### PR DESCRIPTION
Closes #224

Adds a space between article and noun. Didn't include the polyfill as I understood that we don't include that now. If we encounter many users with old (not upgradable) iPads, we could still add it. Doesn't hurt that much.