### PR TITLE
Remove hover for empty word type filters on mobile

### DIFF
--- a/app/components/word_type_dropdown_item_component.html.haml
+++ b/app/components/word_type_dropdown_item_component.html.haml
@@ -1,4 +1,4 @@
 - if has_results?
   = link_to link_title, filter_url, 'data-action': 'click->dropdown#toggle', class: 'no-underline block px-8 py-3 hover:text-primary'
 - else
-  .block.text-gray-300.px-8.py-3.hover:text-primary= link_title
+  .block.text-gray-300.px-8.py-3= link_title


### PR DESCRIPTION
Closes #234

![screengrab-20230302-1915](https://user-images.githubusercontent.com/1394828/222516578-a44e4e49-a25b-49fa-9d19-5cd8cf85f066.gif)
