### PR TITLE
Add search highlights

### DIFF
--- a/app/components/highlighted_search_result_component.html.haml
+++ b/app/components/highlighted_search_result_component.html.haml
@@ -1,0 +1,4 @@
+.flex.items-baseline
+  - parts.each do |part|
+    %span{ class: part.match?(/#{query}/i) ? 'bg-search-highlight' : '' }
+      = part

--- a/app/components/highlighted_search_result_component.rb
+++ b/app/components/highlighted_search_result_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class HighlightedSearchResultComponent < ViewComponent::Base
+  attr_reader :result, :query
+
+  def initialize(result:, query:)
+    @result = result
+    @query = query
+  end
+
+  def parts
+    return [result] unless /^[[:alpha:]]*$/.match?(query)
+
+    result.split(/(#{query})/i).select(&:present?)
+  end
+end

--- a/app/views/homes/_search_result.html.haml
+++ b/app/views/homes/_search_result.html.haml
@@ -5,9 +5,10 @@
     - else
       %div
 
-    .py-2
+    .py-2.flex.items-baseline.gap-1
       - if word.is_a? Noun
-        %span= "#{word.article_definite} "
-      %span.font-bold= word.name
+        = word.article_definite
+      .font-bold
+        = render HighlightedSearchResultComponent.new(result: word.name, query: params.dig(:filterrific, :filter_home))
 
   .uppercase.text-xs.py-2= word.model_name.human

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -25,7 +25,8 @@ module.exports = {
         'primary-selected': '#1E6CE3',
         'gray-background': '#F3F4F6',
         'gray-border': '#E6E6E7',
-        'gray-background-highlight': '#E6E6E6'
+        'gray-background-highlight': '#E6E6E6',
+        'search-highlight': '#FFE085'
       }
     },
   },

--- a/spec/components/highlighted_search_result_component_spec.rb
+++ b/spec/components/highlighted_search_result_component_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HighlightedSearchResultComponent, type: :component do
+  it "splits results correctly" do
+    # Start
+    expect(described_class.new(result: "Haus", query: "ha").parts).to eq %w[Ha us]
+    # Middle
+    expect(described_class.new(result: "Bauhaus", query: "ha").parts).to eq %w[Bau ha us]
+    # End
+    expect(described_class.new(result: "Bauhaus", query: "aus").parts).to eq %w[Bauh aus]
+    # Multiple
+    expect(described_class.new(result: "Bauhaus", query: "au").parts).to eq %w[B au h au s]
+    # Complete word
+    expect(described_class.new(result: "Haus", query: "haus").parts).to eq %w[Haus]
+    # Regex
+    expect(described_class.new(result: "Haus", query: "h.").parts).to eq %w[Haus]
+  end
+end


### PR DESCRIPTION
Closes #194 

Adds highlights to the search results on the homepage. Unfortunately, this reverts the changes of #224. We now have multiple `span` tags for the different parts of the word (highlighted or not). We have to use `flex` there because otherwise we get spaces between the different word parts. We could ensure that there is no newline between the `span` tags, but that doesn't look that good in HAML.

I used the yellow from the design - in the GIF below the color appears too bright.

![screengrab-20230302-2209](https://user-images.githubusercontent.com/1394828/222554587-6e7bcb70-55a3-4e00-87bf-ed092788abe9.gif)
