### PR TITLE
Fix search results when no search params are given

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -6,7 +6,7 @@ class SearchesController < PublicController
   def show
     @filterrific = initialize_filterrific(
       Word,
-      params[:filterrific]
+      (params[:filterrific] || {}).merge(filter_type: params.dig(:filterrific, :filter_type).presence || "")
     ) or return
 
     @words = @filterrific


### PR DESCRIPTION
Closes #202

Fixes the following:

* Enter search term on search results page
* Click on the "x" in the input field to clear the search term
* Scroll down and click a pagination link
* The page was then empty

The problem was that the "word type" filter was also cleared, which resulted in no results.