### PR TITLE
Fix filter width on smaller desktops

### DIFF
--- a/app/views/searches/show.html.haml
+++ b/app/views/searches/show.html.haml
@@ -18,7 +18,7 @@
 
   .bg-gray-background.border-t-4.border-primary.md:border-t.md:border-gray-border
     .pt-0.flex.flex-col.md:flex-row
-      %div(class="md:max-w-[40vh] #{@is_filter_open ? '' : 'hidden'}")
+      %div(class="md:min-w-[25rem] md:max-w-[30vw] #{@is_filter_open ? '' : 'hidden'}")
         = render 'filters/form', f:
       .p-6.pt-0.grow
         = render 'words/index', words: @words


### PR DESCRIPTION
Closes #230

Changes the filter width to be a bit wider.

![screengrab-20230306-2113](https://user-images.githubusercontent.com/1394828/223220399-fd083c41-c037-4917-9411-62169d018c2c.gif)
