### PR TITLE
Add cursor navigation in search results

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -230,4 +230,8 @@
   .miscellaneous div[data-dropdown-target="button"] span {
     @apply text-black;
   }
+
+  .active[data-search-result] {
+    @apply bg-blue-100;
+  }
 }

--- a/app/javascript/controllers/home_search_controller.js
+++ b/app/javascript/controllers/home_search_controller.js
@@ -8,9 +8,29 @@ export default class extends Controller {
     path: String
   }
 
+  connect() {
+    this.currentResultPosition = -1
+  }
+
   input(event) {
-    if (event.key === 'Enter') {
-      this.goToSearchResults()
+    switch(event.key) {
+      case "Enter":
+        if(this.currentResultPosition >= 0) {
+          this.goToActiveSearchResult()
+        } else {
+          this.goToSearchResults()
+        }
+        return
+      case "ArrowDown":
+        this.currentResultPosition += 1
+        this.clampCurrentResultPosition()
+        this.setActiveSearchResult()
+        return
+      case "ArrowUp":
+        this.currentResultPosition -= 1
+        this.clampCurrentResultPosition()
+        this.setActiveSearchResult()
+        return
     }
   }
 
@@ -18,5 +38,34 @@ export default class extends Controller {
     if (this.inputTarget.value.trim().length > 0) {
       window.location = `${this.pathValue}?filterrific[filter_home]=${this.inputTarget.value}`
     }
+  }
+
+  getSearchResults() {
+    return this.element.querySelectorAll('[data-search-result]')
+  }
+
+  clampCurrentResultPosition() {
+    const searchResultsCount = this.getSearchResults().length
+    const current = this.currentResultPosition
+    const min = -1
+    const max = searchResultsCount - 1
+
+    this.currentResultPosition = Math.min(Math.max(current, min), max)
+  }
+
+  setActiveSearchResult() {
+    const searchResults = this.getSearchResults()
+
+    searchResults.forEach(result => result.classList.remove('active'))
+
+    if(this.currentResultPosition >= 0) {
+      searchResults[this.currentResultPosition].classList.add('active')
+    }
+  }
+
+  goToActiveSearchResult() {
+    const searchResults = this.getSearchResults()
+
+    searchResults[this.currentResultPosition].click()
   }
 }

--- a/app/views/homes/_search_result.html.haml
+++ b/app/views/homes/_search_result.html.haml
@@ -1,4 +1,4 @@
-= link_to word, class: 'flex justify-between px-4 border-b' do
+= link_to word, class: 'flex justify-between px-4 border-b', 'data-search-result': true do
   .grid.grid-cols-2.gap-2(style="grid-template-columns: 3rem 1fr")
     - if word.image.attached?
       = image_tag word.image.variant(:thumb), style: 'max-height: 100%'


### PR DESCRIPTION
Closes #185

This adds cursor navigation in the search results. If a result is selected (highlighted in blue), pressing `enter` visits that word's page. If none is selected, enter shows the search results page.

![screengrab-20230306-2314](https://user-images.githubusercontent.com/1394828/223252127-52d73b3c-e302-44c0-a89a-f49927eebcfb.gif)

It doesn't change the value in the search field as Google does it. That would be way more complex, because when we change the value in the input field, the search results will change as well, basically showing only that one word :slightly_smiling_face: 