### PR TITLE
Fix multiple requests being fired when hitting `enter`

### DIFF
--- a/app/javascript/controllers/home_search_controller.js
+++ b/app/javascript/controllers/home_search_controller.js
@@ -12,9 +12,15 @@ export default class extends Controller {
     this.currentResultPosition = -1
   }
 
+  noop(event) {
+    event.preventDefault()
+  }
+
   input(event) {
     switch(event.key) {
       case "Enter":
+        event.preventDefault()
+
         if(this.currentResultPosition >= 0) {
           this.goToActiveSearchResult()
         } else {
@@ -32,6 +38,8 @@ export default class extends Controller {
         this.setActiveSearchResult()
         return
     }
+
+    event.target.form.requestSubmit()
   }
 
   goToSearchResults() {
@@ -66,6 +74,6 @@ export default class extends Controller {
   goToActiveSearchResult() {
     const searchResults = this.getSearchResults()
 
-    searchResults[this.currentResultPosition].click()
+    Turbo.visit(searchResults[this.currentResultPosition].href)
   }
 }

--- a/app/views/homes/_search_form.html.haml
+++ b/app/views/homes/_search_form.html.haml
@@ -1,6 +1,6 @@
 .mt-6
-  = form_for_filterrific @filterrific, html: { data: { turbo_frame: 'words', turbo_action: 'advance', controller: 'form-submission' } } do |f|
+  = form_for_filterrific @filterrific, html: { data: { turbo_frame: 'words', turbo_action: 'advance' } } do |f|
     .mx-auto(class="md:max-w-[50vw]")
       = render OmniSearchFieldComponent.new(form: f, words: @words, on_search_page: false)
 
-    .sr-only= button_tag t('filter.apply'), type: 'submit', title: t('filter.apply')
+    .sr-only= button_tag t('filter.apply'), type: 'submit', title: t('filter.apply'), 'data-action': 'click->home-search#noop'


### PR DESCRIPTION
Related to #257

When hitting `enter` in the search field, two requests are made:

1. The first submits the form via the hidden screen reader submit button. That just displays the search results in the autocomplete.
2. The second wants to visit the page of the selected word

We should only make one request. This PR ensures that only one request is made.

Hopefully that fixes the issues on production as well.