### PR TITLE
Fix migrations on empty database

### DIFF
--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -75,10 +75,10 @@ class Word < ApplicationRecord
 
   before_save :set_consonant_vowel
   before_save :sanitize_slug
-  before_save :sanitize_example_sentences
-  before_save :update_cologne_phonetics
+  before_save :sanitize_example_sentences, if: -> { respond_to?(:example_sentences) }
+  before_save :update_cologne_phonetics, if: -> { respond_to?(:cologne_phonetics) }
 
-  after_save :handle_audio_attachments
+  after_save :handle_audio_attachments, if: -> { respond_to?(:with_tts) }
 
   validates :slug, presence: true, uniqueness: true
 
@@ -192,6 +192,8 @@ class Word < ApplicationRecord
   end
 
   def sanitize_example_sentences
+    return unless example_sentences.is_a? Array
+
     example_sentences
       .map!(&:strip)
       .select!(&:present?)

--- a/db/migrate/20221120163440_add_flash_cards_to_students.rb
+++ b/db/migrate/20221120163440_add_flash_cards_to_students.rb
@@ -1,5 +1,7 @@
 class AddFlashCardsToStudents < ActiveRecord::Migration[7.0]
   def up
+    return unless defined? Student
+
     Student.find_each do |student|
       student.send(:setup_flashcards) if student.flashcard_lists.empty?
     end

--- a/db/migrate/20221202092420_add_example_sentences_to_words.rb
+++ b/db/migrate/20221202092420_add_example_sentences_to_words.rb
@@ -1,16 +1,5 @@
-class Word < ApplicationRecord
-  has_many :related_example_sentences, class_name: 'ExampleSentence', foreign_key: :word_id
-end
-
-class Noun < Word
-  has_many :related_example_sentences, class_name: 'ExampleSentence', foreign_key: :word_id
-end
-
-class Verb < Word
-  has_many :related_example_sentences, class_name: 'ExampleSentence', foreign_key: :word_id
-end
-
-class Adjective < Word
+class LegacyWord < ApplicationRecord
+  self.table_name = 'words'
   has_many :related_example_sentences, class_name: 'ExampleSentence', foreign_key: :word_id
 end
 
@@ -23,9 +12,11 @@ class AddExampleSentencesToWords < ActiveRecord::Migration[7.0]
     add_column :words, :example_sentences, :jsonb, null: false, default: []
 
     Word.find_each do |word|
-      word.update_attribute(
+      legacy_word = LegacyWord.find(word.id)
+
+      word.update_column(
         :example_sentences,
-        word.related_example_sentences.map(&:sentence)
+        legacy_word.related_example_sentences.map(&:sentence).to_json
       )
     end
 

--- a/db/migrate/20221202144813_add_cologne_phonetics_to_words.rb
+++ b/db/migrate/20221202144813_add_cologne_phonetics_to_words.rb
@@ -6,7 +6,7 @@ class AddColognePhoneticsToWords < ActiveRecord::Migration[7.0]
     reversible do |change|
       change.up do
         Word.find_each do |word|
-          word.update_attribute(:cologne_phonetics, ColognePhonetics.encode(word.name))
+          word.update_column(:cologne_phonetics, ColognePhonetics.encode(word.name))
         end
       end
     end


### PR DESCRIPTION
Closes #262

Fixes migrations so that the following works:

```
bin/rails db:create db:migrate
```