### PR TITLE
Fix audio player not appearing on Safari

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -19,6 +19,7 @@
     %meta{:content => "Wort.Schule", :name => "application-name"}/
     %meta{:content => "#00aba9", :name => "msapplication-TileColor"}/
     %meta{:content => "#ffffff", :name => "theme-color"}/
+    = content_for :turbo_meta
 
   %body.h-full(class=background_color)
     .min-h-full.flex.flex-col.justify-between

--- a/app/views/words/_tts.html.haml
+++ b/app/views/words/_tts.html.haml
@@ -2,3 +2,7 @@
 - if word&.audios&.attached?
   - audio = sentence.present? ? word.audio_for_example_sentence(sentence) : word.audio_for_word
   %audio(src="#{url_for audio}" controls)
+
+-# On Safari the audio player does not load when Turbo is used. We have to force a full page reload.
+= content_for :turbo_meta do
+  %meta(name="turbo-visit-control" content="reload")


### PR DESCRIPTION
Closes #228

The audio player not appearing on Safari is a Turbo problem (I assume). When Turbo is disabled the audio player is always displayed.

This PR proposes to disable Turbo on the word's detail page. This fixes the audio player not appearing on Safari (I can reproduce it on the iPad).

I haven't found any negative consequences of that change so far. Search etc. still seem to work.

I'll also try to reproduce it in a vanilla project in my off-time and check with Turbo if that is a bug or not.