### PR TITLE
Change to use dfiferent Safari audio workaround

### DIFF
--- a/app/javascript/controllers/medium_controller.js
+++ b/app/javascript/controllers/medium_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="medium"
+export default class extends Controller {
+  static targets = ['mediaElement']
+
+  connect() {
+    this.reRenderMediaElement()
+  }
+
+  reRenderMediaElement () {
+    const mediaElement = this.mediaElementTarget
+    const clone = mediaElement.cloneNode(true)
+    mediaElement.parentNode.insertBefore(clone, mediaElement)
+    mediaElement.remove()
+  }
+}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -19,7 +19,6 @@
     %meta{:content => "Wort.Schule", :name => "application-name"}/
     %meta{:content => "#00aba9", :name => "msapplication-TileColor"}/
     %meta{:content => "#ffffff", :name => "theme-color"}/
-    = content_for :turbo_meta
 
   %body.h-full(class=background_color)
     .min-h-full.flex.flex-col.justify-between

--- a/app/views/words/_tts.html.haml
+++ b/app/views/words/_tts.html.haml
@@ -1,4 +1,5 @@
 - sentence ||= nil
 - if word&.audios&.attached?
   - audio = sentence.present? ? word.audio_for_example_sentence(sentence) : word.audio_for_word
-  %audio(src="#{url_for audio}" controls)
+  %div(data-controller="medium")
+    %audio(src="#{url_for audio}" controls data-medium-target="mediaElement")

--- a/app/views/words/_tts.html.haml
+++ b/app/views/words/_tts.html.haml
@@ -2,7 +2,3 @@
 - if word&.audios&.attached?
   - audio = sentence.present? ? word.audio_for_example_sentence(sentence) : word.audio_for_word
   %audio(src="#{url_for audio}" controls)
-
--# On Safari the audio player does not load when Turbo is used. We have to force a full page reload.
-= content_for :turbo_meta do
-  %meta(name="turbo-visit-control" content="reload")


### PR DESCRIPTION
Related to #228.

Instead of disabling Turbo completely, this removes and re-adds the audio element. Tested on an iPad.