### PR TITLE
Fix sort order for 100% matches

### DIFF
--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -109,6 +109,18 @@ RSpec.describe Word do
       expect(Noun.filter_home("ähre ")).to include word1
       expect(Noun.filter_home("american  football ")).to include word2
     end
+
+    it "sorts results" do
+      words = %w[Polizeiauto Polizei Polizeihund]
+      objs = words.map { |name| create :noun, name: }
+
+      expect(Noun.filter_home("polizei").map(&:id)).to eq [objs[1].id, objs[0].id, objs[2].id]
+      expect(Noun.filter_home("polizei").map(&:name)).to eq %w[
+        Polizei
+        Polizeiauto
+        Polizeihund
+      ]
+    end
   end
 
   describe "#filter_letters" do


### PR DESCRIPTION
Closes #277 

Search results after this change:

![image](https://user-images.githubusercontent.com/1394828/225961277-6c9a2b69-9ece-4b48-a2ba-77eecccfeb2c.png)

![image](https://user-images.githubusercontent.com/1394828/225961227-6b236011-7ac2-4d6a-aa0e-11a10ca507dd.png)
