### PR TITLE
Fix link to open filter

### DIFF
--- a/app/views/homes/show.html.haml
+++ b/app/views/homes/show.html.haml
@@ -14,7 +14,7 @@
 
     - else
       .mt-12.flex.justify-center
-        = link_to search_path, 'data-turbo-frame': '_top', class: 'button w-auto' do
+        = link_to search_path(is_filter_open: true), 'data-turbo-frame': '_top', class: 'button w-auto' do
           .flex.items-center.gap-2
             = heroicon 'magnifying-glass'
             = t('.advanced_search')


### PR DESCRIPTION
Closes #290

Now the link opens the filter.

![screengrab-20230322-1930](https://user-images.githubusercontent.com/1394828/227003039-6148be7c-3c07-4a84-8035-18e1a19f5f31.gif)
