### PR TITLE
Fix hiding of word lists box when no lists are present

### DIFF
--- a/app/views/words/_lists.html.haml
+++ b/app/views/words/_lists.html.haml
@@ -1,15 +1,17 @@
-= render BoxComponent.new(title: t('words.show.lists.title')) do
-  .flex.flex-wrap.gap-4.p-6
-    - word.accessible_lists(current_ability).sort_by(&:name).each do |list|
-      = link_to list_path(list), class: 'button' do
-        .flex.gap-2
-          = list.name
-          = heroicon 'chevron-right'
+- lists_of_word = word.accessible_lists(current_ability).sort_by(&:name)
+- lists = (List.of_user(current_user) - word.lists).sort_by(&:name)
 
+- if lists_of_word.present? || lists.present?
+  = render BoxComponent.new(title: t('words.show.lists.title')) do
+    .flex.flex-wrap.gap-4.p-6
+      - lists_of_word.each do |list|
+        = link_to list_path(list), class: 'button' do
+          .flex.gap-2
+            = list.name
+            = heroicon 'chevron-right'
 
-  - lists = (List.of_user(current_user) - word.lists).sort_by(&:name)
-  - if lists.present?
-    = form_tag list_add_word_path, class: 'flex gap-2 mt-6 p-6' do
-      = hidden_field_tag :word_id, word.id
-      = select_tag :id, options_from_collection_for_select(lists, :id, :name), class: 'mt-0'
-      %button.button(type="submit")= t('words.show.lists.add')
+    - if lists.present?
+      = form_tag list_add_word_path, class: 'flex gap-2 mt-6 p-6' do
+        = hidden_field_tag :word_id, word.id
+        = select_tag :id, options_from_collection_for_select(lists, :id, :name), class: 'mt-0'
+        %button.button(type="submit")= t('words.show.lists.add')


### PR DESCRIPTION
Closes #295

The box is now only shown when either the word is on lists or the user is logged in and has lists the word could be added to.