### PR TITLE
Change sub title of search results to show meaning

### DIFF
--- a/app/components/word_panel_component.html.haml
+++ b/app/components/word_panel_component.html.haml
@@ -5,7 +5,7 @@
         .flex.items-baseline.gap-1
           = content
           .text-xl.font-bold= word.name
-        .uppercase.text-xs.font-light.mt-3= word.model_name.human
+        .text-xs.font-light.mt-3= word.meaning
 
       .p-1.pr-4.flex.items-center.object-cover
         - if word.image.attached?


### PR DESCRIPTION
Closes #299

We showed the type of the word before, now its meaning.

![image](https://user-images.githubusercontent.com/1394828/229362297-f6f74972-0574-4e53-a328-d8acfa58b572.png)
