### PR TITLE
Add more sophisticated display of search hits

### DIFF
--- a/app/components/highlighted_search_result_component.html.haml
+++ b/app/components/highlighted_search_result_component.html.haml
@@ -1,4 +1,6 @@
-.flex.items-baseline
-  - parts.each do |part|
-    %span{ class: part.match?(/#{query}/i) ? 'bg-search-highlight' : '' }
-      = part
+.flex.items-baseline.gap-1
+  .flex.items-baseline
+    - parts.each do |part|
+      %span{ class: part.match?(/#{query}/i) ? 'bg-search-highlight' : '' }
+        = part.html_safe
+  %span= t hit_in, scope: :words, base: result.full_name

--- a/app/components/highlighted_search_result_component.rb
+++ b/app/components/highlighted_search_result_component.rb
@@ -9,8 +9,21 @@ class HighlightedSearchResultComponent < ViewComponent::Base
   end
 
   def parts
-    return [result] unless /^[[:alpha:]]*$/.match?(query)
+    return [result.name] unless /^[[:alpha:]]*$/.match?(query)
 
-    result.split(/(#{query})/i).select(&:present?)
+    result
+      .public_send(hit_in)
+      .split(/(#{query})/i)
+      .select(&:present?)
+      .map do |part|
+        part.gsub(" ", "&nbsp;")
+      end
+  end
+
+  def hit_in
+    return :full_name if result.name&.match?(/#{query}/i)
+    return :full_plural if result.plural&.match?(/#{query}/i)
+    return :comparative if result.comparative&.match?(/#{query}/i)
+    return :superlative if result.superlative&.match?(/#{query}/i)
   end
 end

--- a/app/models/noun.rb
+++ b/app/models/noun.rb
@@ -45,6 +45,14 @@ class Noun < Word
     %w[ein eine ein ein/eine ein eine/ein ein/eine][genus_id] unless genus_id.nil?
   end
 
+  def full_name
+    [article_definite, name].select(&:present?).join(" ")
+  end
+
+  def full_plural
+    [article_definite(singular: false), plural].select(&:present?).join(" ")
+  end
+
   def self.dummy
     new(
       meaning: "",

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -149,6 +149,10 @@ class Word < ApplicationRecord
     end
   end
 
+  def full_name
+    name
+  end
+
   def accessible_lists(ability)
     List.accessible_by(ability).where(id: lists.pluck(:id))
   end

--- a/app/views/homes/_search_result.html.haml
+++ b/app/views/homes/_search_result.html.haml
@@ -5,10 +5,7 @@
     - else
       %div
 
-    .py-2.flex.items-baseline.gap-1
-      - if word.is_a? Noun
-        = word.article_definite
-      .font-bold
-        = render HighlightedSearchResultComponent.new(result: word.name, query: params.dig(:filterrific, :filter_home))
+    .py-2.flex.items-baseline.font-bold
+      = render HighlightedSearchResultComponent.new(result: word, query: params.dig(:filterrific, :filter_home))
 
   .uppercase.text-xs.py-2= word.model_name.human

--- a/config/locales/words.de.yml
+++ b/config/locales/words.de.yml
@@ -1,0 +1,6 @@
+de:
+  words:
+    full_name: ""
+    full_plural: "(Plural von %{base})"
+    comparative: "(Komparativ von %{base})"
+    superlative: "(Superlativ von %{base})"

--- a/spec/components/highlighted_search_result_component_spec.rb
+++ b/spec/components/highlighted_search_result_component_spec.rb
@@ -5,16 +5,18 @@ require "rails_helper"
 RSpec.describe HighlightedSearchResultComponent, type: :component do
   it "splits results correctly" do
     # Start
-    expect(described_class.new(result: "Haus", query: "ha").parts).to eq %w[Ha us]
+    expect(described_class.new(result: Word.new(name: "Haus"), query: "ha").parts).to eq %w[Ha us]
     # Middle
-    expect(described_class.new(result: "Bauhaus", query: "ha").parts).to eq %w[Bau ha us]
+    expect(described_class.new(result: Word.new(name: "Bauhaus"), query: "ha").parts).to eq %w[Bau ha us]
     # End
-    expect(described_class.new(result: "Bauhaus", query: "aus").parts).to eq %w[Bauh aus]
+    expect(described_class.new(result: Word.new(name: "Bauhaus"), query: "aus").parts).to eq %w[Bauh aus]
     # Multiple
-    expect(described_class.new(result: "Bauhaus", query: "au").parts).to eq %w[B au h au s]
+    expect(described_class.new(result: Word.new(name: "Bauhaus"), query: "au").parts).to eq %w[B au h au s]
     # Complete word
-    expect(described_class.new(result: "Haus", query: "haus").parts).to eq %w[Haus]
+    expect(described_class.new(result: Word.new(name: "Haus"), query: "haus").parts).to eq %w[Haus]
     # Regex
-    expect(described_class.new(result: "Haus", query: "h.").parts).to eq %w[Haus]
+    expect(described_class.new(result: Word.new(name: "Haus"), query: "h.").parts).to eq %w[Haus]
+    # Noun with articlej
+    expect(described_class.new(result: Noun.new(name: "Haus", genus_id: 2), query: "hau").parts).to eq ["das&nbsp;", "Hau", "s"]
   end
 end


### PR DESCRIPTION
Closes #289

Adds a more sophisticated display of the search hits if they are found in the plural, comparative or superlative.

![screengrab-20230403-2143](https://user-images.githubusercontent.com/1394828/229611819-b3fffa8f-8fc4-467a-9ed1-3e146c7feefd.gif)
