### PR TITLE
Change to use generic word panel component

### DIFF
--- a/app/components/word_panel_component.html.haml
+++ b/app/components/word_panel_component.html.haml
@@ -1,4 +1,4 @@
-= link_to word, data: { turbo_frame: '_top' }, id: dom_id(word) do
+- box_content = capture do
   = box padding: false, class: 'h-full' do
     .flex.justify-between.h-full
       .px-4.py-5.sm:px-6
@@ -12,3 +12,9 @@
           = image_tag word.image.variant(:thumb), class: 'w-24 h-full object-cover'
         - else
           .w-24.h-24
+
+- unless menu
+  = link_to word, data: { turbo_frame: '_top' }, id: dom_id(word) do
+    = box_content
+- else
+  = box_content

--- a/app/components/word_panel_component.rb
+++ b/app/components/word_panel_component.rb
@@ -3,9 +3,10 @@
 class WordPanelComponent < ViewComponent::Base
   include ComponentsHelper
 
-  attr_reader :word
+  attr_reader :word, :menu
 
-  def initialize(word:)
+  def initialize(word:, menu: false)
     @word = word
+    @menu = menu
   end
 end

--- a/app/views/flashcards/_word.html.haml
+++ b/app/views/flashcards/_word.html.haml
@@ -1,11 +1,8 @@
-= box class: 'h-full hover:shadow-lg hover:cursor-pointer relative', id: dom_id(word), 'data-controller': "dropdown #{confetti ? 'confetti' : ''}", 'data-action': 'click->dropdown#toggle click@window->dropdown#hide' do
+%div{class: 'h-full hover:shadow-lg hover:cursor-pointer relative !overflow-visible rounded-3xl', style: 'overflow: visible', id: dom_id(word), 'data-controller': "dropdown #{confetti ? 'confetti' : ''}", 'data-action': 'click->dropdown#toggle click@window->dropdown#hide'}
   - menu_id = "menu-#{word.id}"
   - show_actions_label = t('.show_actions')
 
-  .flex.justify-between
-    = with_article word
-    %span.text-gray-500(type="button" data-dropdown-target="button" aria-haspopup="menu" aria-controls=menu_id title=show_actions_label)
-      = heroicon :'ellipsis-horizontal'
+  = render WordPanelComponent.new(word:, menu: true)
 
   .hidden.flex.flex-col.gap-1.absolute.left-0.bg-white.w-full.z-50.p-2.rounded-lg.shadow-lg(id=menu_id role="menu" data-dropdown-target="menu")
     - if list != @lists.first


### PR DESCRIPTION
Closes #312

Changes word panels in Wörterklinik to use the same panel as in the search results.

![screengrab-20230418-1844](https://user-images.githubusercontent.com/1394828/232847055-f227bd41-7c47-4308-b6a2-9dd6759be11a.gif)
