### PR TITLE
Wörterklinik | Tabs

### DIFF
--- a/app/controllers/flashcards_controller.rb
+++ b/app/controllers/flashcards_controller.rb
@@ -4,6 +4,12 @@ class FlashcardsController < ApplicationController
   authorize_resource class: false
 
   def index
-    @lists = current_user.flashcard_lists
+    first_list_id = Flashcards::SECTIONS.first
+    requested_list_id = params[:list].presence || first_list_id
+
+    @is_first_list = requested_list_id.to_s == first_list_id.to_s
+
+    @list = current_user.flashcard_list(requested_list_id)
+    raise ActionController::RoutingError, "Not Found" if @list.blank?
   end
 end

--- a/app/views/flashcards/_tabs.html.haml
+++ b/app/views/flashcards/_tabs.html.haml
@@ -1,0 +1,10 @@
+= turbo_frame_tag :flashcard_tabs, class: 'flex flex-wrap my-6 border-b', target: '_top' do
+  - current_user.flashcard_lists.each do |flashcard_list|
+    - words_count = flashcard_list.words.size
+
+    - if words_count > 0
+      .hover:bg-white.px-4.py-2{class: flashcard_list.flashcard_section == list.flashcard_section ? 'font-bold shadow border bg-white' : ''}
+        = link_to "#{flashcard_list} (#{words_count})", flashcards_path(list: flashcard_list.flashcard_section)
+    - else
+      .text-gray-500.px-4.py-2
+        = flashcard_list

--- a/app/views/flashcards/_word.html.haml
+++ b/app/views/flashcards/_word.html.haml
@@ -5,10 +5,10 @@
   = render WordPanelComponent.new(word:, menu: true)
 
   .hidden.flex.flex-col.gap-1.absolute.left-0.bg-white.w-full.z-50.p-2.rounded-lg.shadow-lg(id=menu_id role="menu" data-dropdown-target="menu")
-    - if list != @lists.first
-      = button_to t('.move_word_to_first_section', first_section: t('activerecord.attributes.list.flashcard_sections.1')), move_word_list_path(@lists.first, word_id: word.id), method: :patch, class: 'button text-xs !w-full'
+    - unless @is_first_list
+      = button_to t('.move_word_to_first_section', first_section: t('activerecord.attributes.list.flashcard_sections.1')), move_word_list_path(current_user.first_flashcard_list, word_id: word.id), method: :patch, class: 'button text-xs !w-full'
 
-    - next_section_list = @lists.find_by(flashcard_section: list.flashcard_section + 1)
+    - next_section_list = current_user.flashcard_list(list.flashcard_section + 1)
     - if next_section_list.present?
       = button_to t('.move_word_to_next_section'), move_word_list_path(next_section_list, word_id: word.id), method: :patch, class: 'button primary !text-xs !w-full'
 

--- a/app/views/flashcards/_words.html.haml
+++ b/app/views/flashcards/_words.html.haml
@@ -1,3 +1,3 @@
-.grid.gap-4.md:grid-cols-3.p-3{id: dom_id(list)}
+.grid.gap-4.md:grid-cols-3{id: dom_id(list)}
   - list.words.ordered_lexigraphically.each do |word|
     = render 'flashcards/word', list:, word:, confetti: false

--- a/app/views/flashcards/index.html.haml
+++ b/app/views/flashcards/index.html.haml
@@ -1,6 +1,4 @@
 = title_with_actions t('.title')
 
-%div
-  - @lists.each.with_index do |list, index|
-    = two_column_card list, '', first: index == 0 do
-      = render 'flashcards/words', list:
+= render 'flashcards/tabs', list: @list
+= render 'flashcards/words', list: @list

--- a/app/views/lists/move_word.turbo_stream.haml
+++ b/app/views/lists/move_word.turbo_stream.haml
@@ -3,3 +3,5 @@
 
 - if @new_list != @lists.first
   = turbo_stream.replace @word, partial: 'flashcards/word', locals: { list: @new_list, word: @word, confetti: true }
+
+= turbo_stream.replace :flashcard_tabs, partial: 'flashcards/tabs', locals: { list: @old_list }


### PR DESCRIPTION
Closes #313 

Changes the display of flashcards to tabs. When moving words, there is now no confetti animation anymore, because the moved word is not visible anymore after moving.

![screengrab-20230418-1918](https://user-images.githubusercontent.com/1394828/232855268-5a7a191c-cb21-47a7-ad9b-a609ac95b82a.gif)
