### PR TITLE
Add cologne phonetics back to main search

### DIFF
--- a/app/components/highlighted_search_result_component.html.haml
+++ b/app/components/highlighted_search_result_component.html.haml
@@ -1,6 +1,9 @@
-.flex.items-baseline.gap-1
-  .flex.items-baseline
-    - parts.each do |part|
-      %span{ class: part.match?(/#{query}/i) ? 'bg-search-highlight' : '' }
-        = part.html_safe
+.flex.flex-wrap.items-baseline.gap-1
+  - if parts.blank?
+    = result.full_name
+  - else
+    .flex.items-baseline
+      - parts.each do |part|
+        %span{ class: part.match?(/#{query}/i) ? 'bg-search-highlight' : '' }
+          = part.html_safe
   %span= t hit_in, scope: :words, base: result.full_name

--- a/app/components/highlighted_search_result_component.rb
+++ b/app/components/highlighted_search_result_component.rb
@@ -9,6 +9,7 @@ class HighlightedSearchResultComponent < ViewComponent::Base
   end
 
   def parts
+    return [] if query.blank?
     return [result.name] unless /^[[:alpha:]]*$/.match?(query)
 
     result

--- a/app/components/highlighted_search_result_component.rb
+++ b/app/components/highlighted_search_result_component.rb
@@ -25,5 +25,6 @@ class HighlightedSearchResultComponent < ViewComponent::Base
     return :full_plural if result.plural&.match?(/#{query}/i)
     return :comparative if result.comparative&.match?(/#{query}/i)
     return :superlative if result.superlative&.match?(/#{query}/i)
+    return :full_name if result.cologne_phonetics&.match?(ColognePhonetics.encode(query))
   end
 end

--- a/app/components/word_panel_component.html.haml
+++ b/app/components/word_panel_component.html.haml
@@ -3,8 +3,11 @@
     .flex.justify-between.h-full
       .px-4.py-5.sm:px-6
         .flex.items-baseline.gap-1
-          = content
-          .text-xl.font-bold= word.name
+          - if name?
+            = name
+          - else
+            = content
+            .text-xl.font-bold= word.name
         .text-xs.font-light.mt-3= word.meaning
 
       .p-1.pr-4.flex.items-center.object-cover

--- a/app/components/word_panel_component.rb
+++ b/app/components/word_panel_component.rb
@@ -3,6 +3,8 @@
 class WordPanelComponent < ViewComponent::Base
   include ComponentsHelper
 
+  renders_one :name
+
   attr_reader :word, :menu
 
   def initialize(word:, menu: false)

--- a/app/controllers/concerns/word_filter.rb
+++ b/app/controllers/concerns/word_filter.rb
@@ -118,7 +118,8 @@ module WordFilter
         where("comparative ILIKE ?", term).select("*, 1 as weight"),
         where("comparative ILIKE ?", "#{query}%").select("*, 2 as weight"),
         where("superlative ILIKE ?", term).select("*, 1 as weight"),
-        where("superlative ILIKE ?", "#{query}%").select("*, 2 as weight")
+        where("superlative ILIKE ?", "#{query}%").select("*, 2 as weight"),
+        filter_cologne_phonetics(query).select("*, 4 as weight")
       ).order(:weight, :name).ids.uniq
 
       Word

--- a/app/views/words/_index.html.haml
+++ b/app/views/words/_index.html.haml
@@ -3,7 +3,10 @@
 
   .grid.my-6.gap-4(class=columns)
     - words.each do |word|
-      = render word
+      = render WordPanelComponent.new(word:) do |component|
+        - component.with_name do
+          .font-bold
+            = render HighlightedSearchResultComponent.new(result: word, query: params.dig(:filterrific, :filter_home))
 
   .pagination-with-actions
     = paginate words

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -106,22 +106,16 @@ RSpec.describe "word filter" do
       visit search_path
     end
 
-    # This spec is currently skipped as phonetic search has ben temporarily disabled
-    it "filters phonetically", js: true, skip: true do
-      # Opening/closing the filter is only necessary because Capybara doesn't
-      # wait for the search to complete
-      click_on t("filter.title")
-      click_on t("filter.title")
-
+    it "filters phonetically", js: true do
       expect(page).to have_content "Fahrrad" # 372
 
-      fill_in t("filter.cologne_phonetics"), with: "Var" # 37
+      fill_in "filterrific[filter_home]", with: "Var" # 37
       expect(page).to have_content "Fahrrad"
 
-      fill_in t("filter.cologne_phonetics"), with: "Hau" # 0
+      fill_in "filterrific[filter_home]", with: "Hau" # 37
       expect(page).not_to have_content "Fahrrad"
 
-      fill_in t("filter.cologne_phonetics"), with: "Vahrad" # 372
+      fill_in "filterrific[filter_home]", with: "Vahrad" # 37
       expect(page).to have_content "Fahrrad"
     end
   end

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -102,20 +102,23 @@ RSpec.describe "word filter" do
   describe "by cologne phonetics" do
     let!(:noun) { create :noun, name: "Fahrrad" }
 
-    before do
+    it "shows all words on initial load", js: true do
       visit search_path
+      expect(page).to have_content "Fahrrad" # 372
     end
 
-    it "filters phonetically", js: true do
-      expect(page).to have_content "Fahrrad" # 372
-
-      fill_in "filterrific[filter_home]", with: "Var" # 37
-      expect(page).to have_content "Fahrrad"
-
-      fill_in "filterrific[filter_home]", with: "Hau" # 37
+    it "removes words phonetically", js: true do
+      visit search_path("filterrific[filter_home]": "Hau") # 0
       expect(page).not_to have_content "Fahrrad"
+    end
 
-      fill_in "filterrific[filter_home]", with: "Vahrad" # 37
+    it "finds exact phonetic match", js: true do
+      visit search_path("filterrific[filter_home]": "Vahrad") # 372
+      expect(page).to have_content "Fahrrad"
+    end
+
+    it "finds partial phonetic match", js: true do
+      visit search_path("filterrific[filter_home]": "Var") # 37
       expect(page).to have_content "Fahrrad"
     end
   end


### PR DESCRIPTION
Closes #314

Adds phonetic search to the main search (sorted at the end of the results).

![screengrab-20230420-1758](https://user-images.githubusercontent.com/1394828/233422120-dab724df-844e-4445-8b0b-4ea7821c3bfe.gif)
