### PR TITLE
Add search highlights on search page

### DIFF
--- a/app/components/highlighted_search_result_component.html.haml
+++ b/app/components/highlighted_search_result_component.html.haml
@@ -1,6 +1,9 @@
-.flex.items-baseline.gap-1
-  .flex.items-baseline
-    - parts.each do |part|
-      %span{ class: part.match?(/#{query}/i) ? 'bg-search-highlight' : '' }
-        = part.html_safe
+.flex.flex-wrap.items-baseline.gap-1
+  - if parts.blank?
+    = result.full_name
+  - else
+    .flex.items-baseline
+      - parts.each do |part|
+        %span{ class: part.match?(/#{query}/i) ? 'bg-search-highlight' : '' }
+          = part.html_safe
   %span= t hit_in, scope: :words, base: result.full_name

--- a/app/components/highlighted_search_result_component.rb
+++ b/app/components/highlighted_search_result_component.rb
@@ -9,6 +9,7 @@ class HighlightedSearchResultComponent < ViewComponent::Base
   end
 
   def parts
+    return [] if query.blank?
     return [result.name] unless /^[[:alpha:]]*$/.match?(query)
 
     result

--- a/app/components/word_panel_component.html.haml
+++ b/app/components/word_panel_component.html.haml
@@ -3,8 +3,11 @@
     .flex.justify-between.h-full
       .px-4.py-5.sm:px-6
         .flex.items-baseline.gap-1
-          = content
-          .text-xl.font-bold= word.name
+          - if name?
+            = name
+          - else
+            = content
+            .text-xl.font-bold= word.name
         .text-xs.font-light.mt-3= word.meaning
 
       .p-1.pr-4.flex.items-center.object-cover

--- a/app/components/word_panel_component.rb
+++ b/app/components/word_panel_component.rb
@@ -3,6 +3,8 @@
 class WordPanelComponent < ViewComponent::Base
   include ComponentsHelper
 
+  renders_one :name
+
   attr_reader :word, :menu
 
   def initialize(word:, menu: false)

--- a/app/views/words/_index.html.haml
+++ b/app/views/words/_index.html.haml
@@ -3,7 +3,10 @@
 
   .grid.my-6.gap-4(class=columns)
     - words.each do |word|
-      = render word
+      = render WordPanelComponent.new(word:) do |component|
+        - component.with_name do
+          .font-bold
+            = render HighlightedSearchResultComponent.new(result: word, query: params.dig(:filterrific, :filter_home))
 
   .pagination-with-actions
     = paginate words


### PR DESCRIPTION
Closes #315 and #316

Adds search highlights also to the search page and adds the extensions from the homepage (like "Plural von das Kind").

![screengrab-20230420-1822](https://user-images.githubusercontent.com/1394828/233427964-ddc3e207-dd5e-46ad-9c95-b60dca606db8.gif)
![image](https://user-images.githubusercontent.com/1394828/233429989-5e055e34-cbf7-4704-a3a1-c4caa4586140.png)
