### PR TITLE
Search | Fix cursor focus

### DIFF
--- a/app/components/omni_search_field_component.html.haml
+++ b/app/components/omni_search_field_component.html.haml
@@ -1,7 +1,9 @@
+- autofocus = !request.path.start_with?(search_path)
+
 .relative.rounded-full.shadow.mx-2.md:mx-0
   .absolute.inset-y-0.left-0.pl-3.flex.items-center.pointer-events-none
     = heroicon 'magnifying-glass', options: {class: 'text-gray-500 sm:text-sm'}
-  = form.text_field :filter_home, data: input_data_attribute, class: 'pl-12 pr-12 bg-gray-50 !rounded-full', autofocus: true, autocomplete: :off, 'data-turbo-permanent': true, 'data-controller': 'reset-search'
+  = form.text_field :filter_home, data: input_data_attribute, class: 'pl-12 pr-12 bg-gray-50 !rounded-full', autofocus:, autocomplete: :off, 'data-turbo-permanent': true, 'data-controller': 'reset-search'
   .absolute.inset-y-0.right-0.flex.items-center
     = link_to reset_filterrific_url, class: 'pr-3 text-gray-500', title: t('filter.reset') do
       = heroicon 'x-mark'

--- a/app/controllers/concerns/word_filter.rb
+++ b/app/controllers/concerns/word_filter.rb
@@ -136,7 +136,7 @@ module WordFilter
 
       query = squeeze query
       term = replace_regex query
-      where("name ILIKE ?", term)
+      where("words.name ILIKE ?", term)
     }
 
     scope :filter_wordstarts, lambda { |query|

--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -3,7 +3,7 @@ module FilterHelper
     form_attribute = "filter_#{attribute}"
 
     inline = input_options.delete(:inline)
-    input_field = form.text_field form_attribute, input_options.deep_merge(data: {action: "input->form-submission#search"})
+    input_field = form.text_field form_attribute, input_options.deep_merge(data: {action: "input->form-submission#search", "turbo-permanent": true})
 
     return input_field if inline
 


### PR DESCRIPTION
Closes #339.

Fixes cursor focus moving back to main search field when entering text somewhere else.

## Caveats

* This loses autofocus on the advanced search page. The autofocus caused the loss of the focus when the search results are refreshed. If this is an issue, we could add some JavaScript which checks whether the focus is set in an input field, and if not, only then focus the main search field.