### PR TITLE
Possibly fix flashing values in the homepage search field

### DIFF
--- a/app/components/omni_search_field_component.html.haml
+++ b/app/components/omni_search_field_component.html.haml
@@ -3,7 +3,7 @@
 .relative.rounded-full.shadow.mx-2.md:mx-0
   .absolute.inset-y-0.left-0.pl-3.flex.items-center.pointer-events-none
     = heroicon 'magnifying-glass', options: {class: 'text-gray-500 sm:text-sm'}
-  = form.text_field :filter_home, data: input_data_attribute, class: 'pl-12 pr-12 bg-gray-50 !rounded-full', autofocus:, autocomplete: :off, 'data-turbo-permanent': true, 'data-controller': 'reset-search'
+  = form.text_field :filter_home, id: search_input_id, data: input_data_attribute, class: 'pl-12 pr-12 bg-gray-50 !rounded-full', autofocus:, autocomplete: :off, 'data-turbo-permanent': true, 'data-controller': 'reset-search'
   .absolute.inset-y-0.right-0.flex.items-center
     = link_to reset_filterrific_url, class: 'pr-3 text-gray-500', title: t('filter.reset') do
       = heroicon 'x-mark'

--- a/app/components/omni_search_field_component.rb
+++ b/app/components/omni_search_field_component.rb
@@ -11,8 +11,8 @@ class OmniSearchFieldComponent < ViewComponent::Base
     @total_count = total_count
   end
 
-  def on_search_page?
-    !!@on_search_page
+  def search_input_id
+    !!@on_search_page ? "advanced_search" : "homepage_search"
   end
 
   def input_data_attribute


### PR DESCRIPTION
Closes #342.

This possibly fixes flashing text in the search input field of the homepage. I have seen this happening before, but couldn't reliably reproduce it, so I'm not 100% sure whether this fixes the issue.