### PR TITLE
Fix cursor focus when changing keywords

### DIFF
--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -25,7 +25,7 @@ module FilterHelper
   def filter_select_field_with_and_or(form, attribute, collection:)
     form_attribute = "filter_#{attribute}"
 
-    content_tag :div, class: "input" do
+    content_tag :div, class: "input", id: "#{attribute}_multiselect", "data-turbo-permanent": true do
       concat form.label form_attribute, I18n.t("filter.#{attribute}")
       concat(content_tag(:div, class: "flex gap-2 items-start") do
         concat(form.fields_for(form_attribute) do |fields|


### PR DESCRIPTION
Closes #351

Changes to make the keyword input field permanent, so that it doesn't lose focuse on updates.