### PR TITLE
Fix rails development startup regarding better_errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem "validate_url"
 gem "view_component"
 
 group :development do
-  gem "better_errors", "2.10.0"
+  gem "better_errors"
   gem "binding_of_caller"
   gem "letter_opener"
   gem "web-console"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     bcrypt (3.1.18)
-    better_errors (2.10.0)
+    better_errors (2.10.1)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
@@ -503,7 +503,7 @@ PLATFORMS
 DEPENDENCIES
   active_record_extended
   active_storage_svg_sanitizer
-  better_errors (= 2.10.0)
+  better_errors
   binding_of_caller
   bootsnap
   cancancan


### PR DESCRIPTION
`better_errors` has been updated and fixed the development startup of the Rails server.

cf. https://github.com/BetterErrors/better_errors/issues/516