### PR TITLE
Wörterklinik | Add/Remove words when adding/removing users to/from a learning group

### DIFF
--- a/app/controllers/learning_group_memberships/requests_controller.rb
+++ b/app/controllers/learning_group_memberships/requests_controller.rb
@@ -26,6 +26,7 @@ module LearningGroupMemberships
       authorize! :accept_request, @learning_group_membership
 
       notice = if @learning_group_membership.update(access: "granted")
+        Flashcards.add_user(@learning_group_membership.learning_group, current_user)
         t("notices.learning_group_memberships.accepted")
 
       else

--- a/app/controllers/learning_groups/user_generations_controller.rb
+++ b/app/controllers/learning_groups/user_generations_controller.rb
@@ -26,6 +26,7 @@ module LearningGroups
           learning_group: @learning_group,
           access: "granted"
         )
+        Flashcards.add_user(@learning_group, user)
       end
     end
 

--- a/app/models/learning_group_membership.rb
+++ b/app/models/learning_group_membership.rb
@@ -8,4 +8,12 @@ class LearningGroupMembership < ApplicationRecord
   enumerize :role, in: %i[member group_admin], scope: true
 
   validates :user, uniqueness: {scope: :learning_group_id}
+
+  after_destroy :remove_words
+
+  private
+
+  def remove_words
+    Flashcards.remove_user(learning_group, user)
+  end
 end

--- a/app/services/flashcards.rb
+++ b/app/services/flashcards.rb
@@ -32,4 +32,32 @@ class Flashcards
       end
     end
   end
+
+  def self.add_user(learning_group, user)
+    learning_group.lists.each do |list|
+      list.words.each do |word|
+        next if user.word_in_flashcards?(word)
+
+        user.first_flashcard_list.words << word
+      end
+    end
+  end
+
+  def self.remove_user(learning_group, user)
+    remove_word_ids = learning_group.lists.joins(:words).pluck("words.id")
+    word_ids_to_keep = user
+      .learning_groups
+      .reject { |group| group.id == learning_group.id }
+      .map { |group| group.lists.joins(:words).pluck("words.id").uniq }
+      .flatten
+    word_ids_to_remove = remove_word_ids - word_ids_to_keep
+
+    SECTIONS.each do |section|
+      list = user.flashcard_list(section)
+
+      obsolete_word_ids = list.words.pluck(:id) & word_ids_to_remove
+
+      list.words.delete(Word.find(obsolete_word_ids)) if obsolete_word_ids.present?
+    end
+  end
 end

--- a/spec/features/flashcards_spec.rb
+++ b/spec/features/flashcards_spec.rb
@@ -195,5 +195,30 @@ RSpec.describe "flash cards" do
       expect(page).to have_content noun1.name
       expect(page).not_to have_content noun2.name
     end
+
+    it "adds words when generating a user" do
+      expect(learning_group.users).to be_empty
+
+      visit learning_group_path(learning_group)
+      click_on t("learning_groups.show.assign_list")
+      expect(page).to have_content t("learning_pleas.new.title")
+      click_on t("learning_pleas.new.assign")
+
+      expect(learning_group.lists).to match_array [word_list]
+
+      # Generate user
+      click_on t("learning_groups.show.generate_accounts")
+      fill_in t("learning_groups.user_generations.new.amount"), with: "1"
+      click_on t("actions.create")
+
+      generated_user = learning_group.users.first
+      expect(generated_user).to be_confirmed
+      expect(generated_user.flashcard_list(1).words).to match_array [noun1, noun2]
+
+      login_as generated_user
+      visit flashcards_path
+      expect(page).to have_content noun1.name
+      expect(page).to have_content noun2.name
+    end
   end
 end

--- a/spec/features/flashcards_spec.rb
+++ b/spec/features/flashcards_spec.rb
@@ -85,4 +85,115 @@ RSpec.describe "flash cards" do
       expect(page).not_to have_content noun3.name
     end
   end
+
+  describe "add/remove users modifies their words" do
+    let(:lecturer) { create :lecturer }
+    let!(:learning_group) { create :learning_group, owner: lecturer }
+    let(:word_list) { create :list, user: lecturer, visibility: :public }
+    let(:user) { create :guest }
+    let(:noun1) { create :noun, name: "Adler" }
+    let(:noun2) { create :noun, name: "Bauer" }
+
+    before do
+      word_list.words << noun1
+      word_list.words << noun2
+      login_as lecturer
+    end
+
+    it "removes words when removing a user" do
+      LearningGroupMembership.create!(learning_group:, user:, access: :granted)
+
+      visit learning_group_path(learning_group)
+      click_on t("learning_groups.show.assign_list")
+      expect(page).to have_content t("learning_pleas.new.title")
+      click_on t("learning_pleas.new.assign")
+
+      expect(learning_group.lists).to match_array [word_list]
+      expect(user.flashcard_list(1).words).to match_array [noun1, noun2]
+
+      # Remove user
+      login_as lecturer
+      visit learning_group_path(learning_group)
+      within "##{dom_id(user)}" do
+        click_on t("actions.remove")
+      end
+
+      user.reload
+      expect(user.flashcard_list(1).words).to be_empty
+
+      login_as user
+      visit flashcards_path
+      expect(page).not_to have_content noun1.name
+      expect(page).not_to have_content noun2.name
+    end
+
+    it "adds words when adding a user" do
+      visit learning_group_path(learning_group)
+      click_on t("learning_groups.show.assign_list")
+      expect(page).to have_content t("learning_pleas.new.title")
+      click_on t("learning_pleas.new.assign")
+
+      expect(learning_group.lists).to match_array [word_list]
+
+      # Add user
+      click_on t("learning_groups.show.assign_user")
+      fill_in t("activerecord.attributes.learning_group_membership.user"), with: user.email
+      click_on t("learning_group_memberships.new.assign")
+
+      # User accepts invitation
+      login_as user
+      visit profile_path
+      click_on t("profiles.show.accept")
+
+      user.reload
+      expect(user.learning_group_memberships).to be_present
+      expect(user.flashcard_list(1).words).to match_array [noun1, noun2]
+
+      visit flashcards_path
+      expect(page).to have_content noun1.name
+      expect(page).to have_content noun2.name
+    end
+
+    it "does not remove a word when it is also in another learning group" do
+      LearningGroupMembership.create!(learning_group:, user:, access: :granted)
+
+      visit learning_group_path(learning_group)
+      click_on t("learning_groups.show.assign_list")
+      expect(page).to have_content t("learning_pleas.new.title")
+      click_on t("learning_pleas.new.assign")
+
+      expect(learning_group.lists).to match_array [word_list]
+      expect(user.flashcard_list(1).words).to match_array [noun1, noun2]
+
+      other_learning_group = create(:learning_group, owner: lecturer)
+      other_word_list = create(:list, user: lecturer, visibility: :public)
+      other_word_list.words << noun1
+      LearningGroupMembership.create!(learning_group: other_learning_group, user:, access: :granted)
+
+      visit learning_group_path(other_learning_group)
+      click_on t("learning_groups.show.assign_list")
+      expect(page).to have_content t("learning_pleas.new.title")
+      within "##{dom_id(other_word_list)}" do
+        click_on t("learning_pleas.new.assign")
+      end
+
+      expect(other_learning_group.lists).to match_array [other_word_list]
+      expect(user.flashcard_list(1).words).to match_array [noun1, noun2]
+
+      # Remove user
+      login_as lecturer
+      visit learning_group_path(learning_group)
+      within "##{dom_id(user)}" do
+        click_on t("actions.remove")
+      end
+
+      user.reload
+      expect(user.flashcard_list(1).words).to match_array [noun1]
+
+      login_as user
+      visit flashcards_path
+      expect(page).to have_content noun1.name
+      expect(page).not_to have_content noun2.name
+    end
+  end
 end


### PR DESCRIPTION
Closes #317.

## Changes

* When adding a user to a learning group, that user will receive all words from the group.
* When removing a user from a learning group, all words of that group will be removed from the user. Except words which are also present in other groups the user belongs to.
* When generating user accounts in a learning group, all users now receive all words from the group.