### PR TITLE
Change cologne phonetics to include multiple word forms

### DIFF
--- a/app/components/highlighted_search_result_component.rb
+++ b/app/components/highlighted_search_result_component.rb
@@ -26,6 +26,8 @@ class HighlightedSearchResultComponent < ViewComponent::Base
     return :full_plural if result.plural&.match?(/#{query}/i)
     return :comparative if result.comparative&.match?(/#{query}/i)
     return :superlative if result.superlative&.match?(/#{query}/i)
-    return :full_name if result.cologne_phonetics&.match?(ColognePhonetics.encode(query))
+    return :full_name if result.cologne_phonetics&.any? do |term|
+      term.match?(ColognePhonetics.encode(query))
+    end
   end
 end

--- a/app/controllers/concerns/word_filter.rb
+++ b/app/controllers/concerns/word_filter.rb
@@ -181,7 +181,7 @@ module WordFilter
       return if query.blank?
 
       query = squeeze query
-      where("cologne_phonetics ILIKE ?", ColognePhonetics.encode(query))
+      where("? = ANY(cologne_phonetics)", ColognePhonetics.encode(query))
     }
 
     scope :filter_letters, lambda { |query|

--- a/app/models/adjective.rb
+++ b/app/models/adjective.rb
@@ -21,4 +21,14 @@ class Adjective < Word
       irregular_comparison: false
     )
   end
+
+  private
+
+  def cologne_phonetics_terms
+    [
+      name,
+      comparative,
+      superlative
+    ]
+  end
 end

--- a/app/models/noun.rb
+++ b/app/models/noun.rb
@@ -85,4 +85,13 @@ class Noun < Word
       singularetantum: false
     )
   end
+
+  private
+
+  def cologne_phonetics_terms
+    [
+      name,
+      plural
+    ]
+  end
 end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -213,8 +213,14 @@ class Word < ApplicationRecord
       .select!(&:present?)
   end
 
+  def cologne_phonetics_terms
+    [name]
+  end
+
   def update_cologne_phonetics
-    self.cologne_phonetics = ColognePhonetics.encode(name)
+    self.cologne_phonetics = cologne_phonetics_terms.filter_map do |term|
+      ColognePhonetics.encode(term).presence
+    end
   end
 
   # Hooks to react to changes in the with_tts, name and example_sentences attributes and purge or (re)generate audio

--- a/db/migrate/20230823174305_change_cologne_phonetics_to_array.rb
+++ b/db/migrate/20230823174305_change_cologne_phonetics_to_array.rb
@@ -1,0 +1,17 @@
+class ChangeColognePhoneticsToArray < ActiveRecord::Migration[7.0]
+  def up
+    remove_column :words, :cologne_phonetics
+    add_column :words, :cologne_phonetics, :string, array: true, default: []
+
+    Word.find_each do |word|
+      word.send(:update_cologne_phonetics)
+      word.save(validate: false)
+    end
+  end
+
+  def down
+    Word.find_each do |word|
+      word.update_column(:cologne_phonetics, ColognePhonetics.encode(word.name))
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_22_183240) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_23_174305) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -411,10 +411,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_22_183240) do
     t.integer "function_type"
     t.string "type", null: false
     t.jsonb "example_sentences", default: [], null: false
-    t.string "cologne_phonetics"
     t.bigint "hit_counter", default: 0, null: false
     t.boolean "with_tts", default: true, null: false
-    t.index ["cologne_phonetics"], name: "index_words_on_cologne_phonetics"
+    t.string "cologne_phonetics", default: [], array: true
     t.index ["genus_feminine_id"], name: "index_words_on_genus_feminine_id"
     t.index ["genus_id"], name: "index_words_on_genus_id"
     t.index ["genus_masculine_id"], name: "index_words_on_genus_masculine_id"

--- a/spec/models/history_spec.rb
+++ b/spec/models/history_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "tracking change history" do
     expect(updated_version.changeset.except("updated_at")).to eq({
       "consonant_vowel" => ["VKKVK", "KVVK"],
       "name" => ["Adler", "Haus"],
-      "cologne_phonetics" => ["0257", "08"]
+      "cologne_phonetics" => [["0257"], ["08"]]
     })
   end
 

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -447,17 +447,17 @@ RSpec.describe Word do
 
   describe "#cologne_phonetics" do
     it "creates phonetics when creating a word" do
-      word = create :noun, name: "Adler"
-      expect(word.cologne_phonetics).to eq "0257"
+      word = create :noun, name: "Adler", plural: "Häuser"
+      expect(word.cologne_phonetics).to eq ["0257", "087"]
     end
 
     it "updates phonetics when updating a word" do
       word = create :noun, name: "Adler"
-      expect(word.cologne_phonetics).to eq "0257"
+      expect(word.cologne_phonetics).to eq ["0257"]
 
       word.update!(name: "Haus")
       word.reload
-      expect(word.cologne_phonetics).to eq "08"
+      expect(word.cologne_phonetics).to eq ["08"]
     end
   end
 


### PR DESCRIPTION
Closes #327

Allows multiple forms of a word to be represented and searched for phonetically.

![image](https://github.com/wort-schule/wort.schule/assets/1394828/2b902ffa-db99-464b-80c4-6adeb0bb6ab7)gg