### PR TITLE
Filter | Loss of focus

### DIFF
--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -13,22 +13,24 @@ module FilterHelper
     end
   end
 
-  def filter_select_field(form, attribute, collection:)
+  def filter_select_field(attribute, collection:)
     form_attribute = "filter_#{attribute}"
+    form_attribute_with_object = "filterrific[#{form_attribute}]"
 
     content_tag :div, class: "input" do
-      concat form.label form_attribute, I18n.t("filter.#{attribute}")
-      concat form.select form_attribute, collection, {include_blank: true, selected: @filterrific.public_send(form_attribute)}, data: {action: "input->form-submission#search"}, class: "w-full", disabled: collection.empty?
+      concat label_tag form_attribute_with_object, I18n.t("filter.#{attribute}")
+      concat select_tag form_attribute_with_object, options_for_select(collection, @filterrific.public_send(form_attribute)), include_blank: true, data: {action: "input->form-submission#search"}, class: "w-full", disabled: collection.empty?
     end
   end
 
-  def filter_select_field_with_and_or(form, attribute, collection:)
+  def filter_select_field_with_and_or(attribute, collection:)
     form_attribute = "filter_#{attribute}"
+    form_attribute_with_object = "filterrific[#{form_attribute}]"
 
     content_tag :div, class: "input", id: "#{attribute}_multiselect" do
-      concat form.label form_attribute, I18n.t("filter.#{attribute}")
+      concat label_tag form_attribute_with_object, I18n.t("filter.#{attribute}")
       concat(content_tag(:div, class: "flex gap-2 items-start") do
-        concat(form.fields_for(form_attribute) do |fields|
+        concat(fields_for(form_attribute_with_object) do |fields|
           concat fields.select :conjunction, [[I18n.t("filter.and"), "and"], [I18n.t("filter.or"), "or"]], {}, data: {action: "input->form-submission#search"}, style: "flex-shrink: 3"
           concat fields.select attribute, collection, {include_blank: true, selected: @filterrific.public_send(form_attribute)&.dig(attribute)}, multiple: true, data: {action: "input->form-submission#search", controller: "select"}, class: "select default-input w-full flex-grow", style: "flex-shrink: 1"
         end)

--- a/app/views/filters/_form.html.haml
+++ b/app/views/filters/_form.html.haml
@@ -1,10 +1,5 @@
 - if @mode.show_panel?
   %div(class="md:min-w-[25rem] md:max-w-[30vw]")
-    - sources = params.dig(:filterrific, :filter_home).blank? ? Source.accessible_by(current_ability) : Source.accessible_by(current_ability).where(id: @all_words.joins(:sources).pluck('sources.id'))
-    - topics = params.dig(:filterrific, :filter_home).blank? ? Topic.all : Topic.where(id: @all_words.joins(:topics).pluck('topics.id'))
-    - hierarchies = params.dig(:filterrific, :filter_home).blank? ? Hierarchy.all : Hierarchy.where(id: @all_words.pluck(:hierarchy_id))
-    - keywords = @all_words.count == Word.count ? Word.all : Word.where(id: Keyword.where(word_id: @all_words.pluck(:id)).pluck(:keyword_id))
-
     .ci-filter.p-5.bg-gray-background-highlight
       .flex.justify-center
         = link_to url_for(params.permit!.merge(mode: :omni)), class: 'flex mb-6 button items-center gap-1', 'data-turbo-frame': '_top' do
@@ -18,9 +13,9 @@
         = filter_text_field f, :wordends, inline: true, label: false, placeholder: t('filter.wordends')
       .mt-4
       = filter_text_field f, :syllablescontains
-      = filter_select_field f, :topic, collection: topics.as_collection
-      = filter_select_field f, :hierarchy, collection: hierarchies.as_collection
-      = filter_select_field_with_and_or f, :keywords, collection: keywords.as_collection
+      = render partial: 'filters/topics'
+      = render partial: 'filters/hierarchies'
+      = render partial: 'filters/keywords'
 
       .mt-4
         - unless @mode.show_power_options?
@@ -28,10 +23,10 @@
 
         - if @mode.show_power_options?
           = filter_text_field f, :letters
-          = filter_select_field f, :source, collection: sources.order(:name).map { |s| [s.name, s.id] }
+          = render partial: 'filters/sources'
           = filter_text_field f, :consonant_vowel, placeholder: 'KVVK', style: 'text-transform: uppercase', oninput: "this.value = this.value.replace(/[^KVkv]/, '')"
-          = filter_select_field_with_and_or f, :phenomenons, collection: Phenomenon.as_collection
-          = filter_select_field_with_and_or f, :strategies, collection: Strategy.as_collection
+          = filter_select_field_with_and_or :phenomenons, collection: Phenomenon.as_collection
+          = filter_select_field_with_and_or :strategies, collection: Strategy.as_collection
           = filter_check_box_field f, :foreign
           = filter_check_box_field f, :prototype
           = filter_check_box_field f, :compound

--- a/app/views/filters/_hierarchies.html.haml
+++ b/app/views/filters/_hierarchies.html.haml
@@ -1,0 +1,4 @@
+- hierarchies = @all_words.count == Word.count ? Hierarchy.all : Hierarchy.where(id: @all_words.pluck(:hierarchy_id))
+
+= turbo_frame_tag :filter_hierarchies, class: 'block input' do
+  = filter_select_field :hierarchy, collection: hierarchies.as_collection

--- a/app/views/filters/_keywords.html.haml
+++ b/app/views/filters/_keywords.html.haml
@@ -1,0 +1,4 @@
+- keywords = @all_words.count == Word.count ? Word.all : Word.where(id: Keyword.where(word_id: @all_words.pluck(:id)).pluck(:keyword_id))
+
+= turbo_frame_tag :filter_keywords, class: 'block input' do
+  = filter_select_field_with_and_or :keywords, collection: keywords.as_collection

--- a/app/views/filters/_sources.html.haml
+++ b/app/views/filters/_sources.html.haml
@@ -1,0 +1,4 @@
+- sources = @all_words.count == Word.count ? Source.accessible_by(current_ability) : Source.accessible_by(current_ability).where(id: @all_words.joins(:sources).pluck('sources.id'))
+
+= turbo_frame_tag :filter_sources, class: 'block input' do
+  = filter_select_field :source, collection: sources.order(:name).map { |s| [s.name, s.id] }

--- a/app/views/filters/_topics.html.haml
+++ b/app/views/filters/_topics.html.haml
@@ -1,0 +1,4 @@
+- topics = @all_words.count == Word.count ? Topic.all : Topic.where(id: @all_words.joins(:topics).pluck('topics.id'))
+
+= turbo_frame_tag :filter_topics, class: 'block input' do
+  = filter_select_field :topic, collection: topics.as_collection

--- a/app/views/searches/_omni_search.html.haml
+++ b/app/views/searches/_omni_search.html.haml
@@ -2,9 +2,5 @@
   .flex.flex-wrap.gap-4.justify-center.items-end.px-8.md:py-8
     .flex-grow
       = render OmniSearchFieldComponent.new(on_search_page: true, total_count: @counts[:all])
-    %div
-      - unless @mode.show_panel?
-        = link_to url_for(params.permit!.merge(mode: :advanced)), class: 'button', 'data-turbo-frame': '_top' do
-          .flex.items-center.gap-1
-            = heroicon 'sparkles'
-            = t('filter.open')
+    = turbo_frame_tag :open_advanced_link do
+      = render 'open_advanced_link'

--- a/app/views/searches/_open_advanced_link.html.haml
+++ b/app/views/searches/_open_advanced_link.html.haml
@@ -1,0 +1,6 @@
+%div
+  - unless @mode.show_panel?
+    = link_to url_for(params.permit!.merge(mode: :advanced)), class: 'button', 'data-turbo-frame': '_top' do
+      .flex.items-center.gap-1
+        = heroicon 'sparkles'
+        = t('filter.open')

--- a/app/views/searches/show.turbo_stream.haml
+++ b/app/views/searches/show.turbo_stream.haml
@@ -5,6 +5,7 @@
 = turbo_stream.update :words do
   = render 'words/index', words: @words
 
-= turbo_stream.update :advanced_search_fields do
-  - fields_for @filterrific do |f|
-    = render 'filters/form', f:
+= turbo_stream.update :filter_sources, partial: 'filters/sources'
+= turbo_stream.update :filter_topics, partial: 'filters/topics'
+= turbo_stream.update :filter_hierarchies, partial: 'filters/hierarchies'
+= turbo_stream.update :filter_keywords, partial: 'filters/keywords'

--- a/app/views/searches/show.turbo_stream.haml
+++ b/app/views/searches/show.turbo_stream.haml
@@ -1,3 +1,5 @@
+= turbo_stream.update :open_advanced_link, partial: 'open_advanced_link'
+
 = turbo_stream.update :word_type_filter, partial: 'word_type_filter'
 
 = turbo_stream.update :words do


### PR DESCRIPTION
This should fix #351 again. That is, focus should be kept while searching.

The problem was that all advanced filters were rendered again when the filters changed. Now we only render the elements again which change (topics, hierarchies, etc.).