### PR TITLE
Fix ambiguous column error

### DIFF
--- a/app/controllers/concerns/word_filter.rb
+++ b/app/controllers/concerns/word_filter.rb
@@ -199,7 +199,7 @@ module WordFilter
         .chars
         .uniq
 
-      where("name ~* ?", letters.map { |letter| "(?=.*#{letter})" }.join)
+      where("words.name ~* ?", letters.map { |letter| "(?=.*#{letter})" }.join)
     }
 
     scope :filter_source, lambda { |source|


### PR DESCRIPTION
Closes #442 

Fixes the following error:

```
ActiveRecord::StatementInvalid - PG::AmbiguousColumn: ERROR:  column reference "name" is ambiguous
LINE 1: ... "topics"."id" = "topics_words"."topic_id" WHERE (name ~* '(...
```