### PR TITLE
Fix initial display of only used keywords

### DIFF
--- a/app/views/filters/_keywords.html.haml
+++ b/app/views/filters/_keywords.html.haml
@@ -1,4 +1,4 @@
-- keywords = @all_words.count == Word.count ? Word.all : Word.where(id: Keyword.where(word_id: @all_words.pluck(:id)).pluck(:keyword_id))
+- keywords = Word.where(id: Keyword.where(word_id: @all_words.pluck(:id)).pluck(:keyword_id))
 
 = turbo_frame_tag :filter_keywords, class: 'block input' do
   = filter_select_field_with_and_or :keywords, collection: keywords.as_collection


### PR DESCRIPTION
Closes #437

This fixes the inital display of the **keywords** in the search. We only want to show used keywords, not all words.