### PR TITLE
Add reset filter button

### DIFF
--- a/app/views/filters/_form.html.haml
+++ b/app/views/filters/_form.html.haml
@@ -1,11 +1,11 @@
 - if @mode.show_panel?
   %div(class="md:min-w-[25rem] md:max-w-[30vw]")
     .ci-filter.p-5.bg-gray-background-highlight
-      .flex.flex-wrap.gap-2.justify-center
-        = link_to url_for(params.permit!.merge(mode: :omni)), class: 'flex mb-6 button items-center gap-1', 'data-turbo-frame': '_top' do
+      .flex.flex-wrap.gap-2.justify-center.mb-6
+        = link_to url_for(params.permit!.merge(mode: :omni)), class: 'flex button items-center gap-1', 'data-turbo-frame': '_top' do
           = heroicon 'x-mark'
           = t('filter.close')
-        = link_to t('filter.reset'), reset_filterrific_url(mode: :advanced), class: 'flex mb-6 button items-center gap-1', 'data-turbo-frame': '_top'
+        = link_to t('filter.reset'), reset_filterrific_url(mode: :advanced), class: 'flex button items-center gap-1', 'data-turbo-frame': '_top'
 
       %div= t 'filter.word_contains'
       .flex.gap-2

--- a/app/views/filters/_form.html.haml
+++ b/app/views/filters/_form.html.haml
@@ -1,10 +1,11 @@
 - if @mode.show_panel?
   %div(class="md:min-w-[25rem] md:max-w-[30vw]")
     .ci-filter.p-5.bg-gray-background-highlight
-      .flex.justify-center
+      .flex.flex-wrap.gap-2.justify-center
         = link_to url_for(params.permit!.merge(mode: :omni)), class: 'flex mb-6 button items-center gap-1', 'data-turbo-frame': '_top' do
           = heroicon 'x-mark'
           = t('filter.close')
+        = link_to t('filter.reset'), reset_filterrific_url(mode: :advanced), class: 'flex mb-6 button items-center gap-1', 'data-turbo-frame': '_top'
 
       %div= t 'filter.word_contains'
       .flex.gap-2

--- a/config/locales/filter.de.yml
+++ b/config/locales/filter.de.yml
@@ -2,7 +2,7 @@ de:
   filter:
     title: Filter
     apply: Filtern
-    reset: Filter löschen
+    reset: Suchfilter löschen
     all: Alle
     and: und
     or: oder

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe "word filter" do
       expect(page).to have_content "Abend"
       expect(page).not_to have_content "Bach"
 
-      click_on t("filter.reset")
+      within "#advanced_search_fields" do
+        click_on t("filter.reset")
+      end
 
       words.each do |word|
         expect(page).to have_content word
@@ -115,6 +117,7 @@ RSpec.describe "word filter" do
       expect(page).to have_content "abstrakt"
 
       click_on t("filter.add_words_to_list")
+      expect(page).to have_select "list_id"
       click_on t("words.show.lists.add")
 
       expect(list.words).to match_array [noun, verb, adjective]


### PR DESCRIPTION
Closes #435

Adds a button to reset everything in the filter:

![screengrab-20240517-2100](https://github.com/wort-schule/wort.schule/assets/1394828/42bb1abf-58f1-429a-a498-24d7073c3759)
