### PR TITLE
Detail page | Fresch symbols

### DIFF
--- a/app/components/word_header_component.html.haml
+++ b/app/components/word_header_component.html.haml
@@ -11,9 +11,12 @@
         - properties.each do |property|
           = property
 
-      - if montessori_symbol.present?
-        .w-full.flex.flex-col.gap-4.items-end.lg:items-start
+      .w-full.flex.flex-col.gap-4.items-end.lg:items-start
+        - if montessori_symbol.present?
           = image_tag montessori_symbol, class: "word-symbol"
+        - word.strategies.each do |strategy|
+          - if strategy.fresch_symbol.attached?
+            = image_tag strategy.fresch_symbol, class: "word-symbol"
 
   .m-6.max-w-96(style="grid-area: image")
     - if word.image.attached?

--- a/app/controllers/strategies_controller.rb
+++ b/app/controllers/strategies_controller.rb
@@ -48,7 +48,7 @@ class StrategiesController < ApplicationController
 
   def strategy_params
     params.require(:strategy).permit(
-      :name, :description
+      :name, :description, :fresch_symbol
     )
   end
 end

--- a/app/models/strategy.rb
+++ b/app/models/strategy.rb
@@ -1,4 +1,6 @@
 class Strategy < ApplicationRecord
   has_and_belongs_to_many :words
   validates_presence_of :name
+
+  has_one_attached :fresch_symbol
 end

--- a/app/views/strategies/_form.html.haml
+++ b/app/views/strategies/_form.html.haml
@@ -3,6 +3,7 @@
     = box_content do
       = f.input :name, autofocus: true
       = f.input :description
+      = f.input :fresch_symbol
 
     = box_footer do
       = f.submit

--- a/app/views/strategies/_strategy.html.haml
+++ b/app/views/strategies/_strategy.html.haml
@@ -1,3 +1,10 @@
 = link_if(can?(:show, strategy), strategy, id: dom_id(strategy)) do
   = box class: 'h-full' do
-    = strategy.name
+    .flex.justify-between.h-full
+      = strategy.name
+
+      .flex.items-center.object-cover
+        - if strategy.fresch_symbol.attached?
+          = image_tag strategy.fresch_symbol, class: 'w-24 h-full object-cover'
+        - else
+          .w-24.h-24

--- a/app/views/strategies/show.html.haml
+++ b/app/views/strategies/show.html.haml
@@ -10,6 +10,10 @@
       = render(list.add(Strategy.human_attribute_name(:description))) do
         = @strategy.description
 
+      = render(list.add(Strategy.human_attribute_name(:fresch_symbol))) do
+        - if @strategy.fresch_symbol.attached?
+          = image_tag @strategy.fresch_symbol
+
 = render 'words/usages'
 
 .pagination-with-actions

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -153,6 +153,7 @@ de:
       strategy:
         name: Bezeichnung
         description: Beschreibung
+        fresch_symbol: Fresch Symbol
       compound_interfix:
         name: Bezeichnung
       compound_preconfix:


### PR DESCRIPTION
Closes #114.

## Changes

- Add image upload to strategies

<img width="739" alt="image" src="https://github.com/wort-schule/wort.schule/assets/1394828/491ba786-9a1a-4b11-ae1e-0c58ec80eedc">

- Add display of strategies on the word

<img width="731" alt="image" src="https://github.com/wort-schule/wort.schule/assets/1394828/e2725fdd-dfae-417b-babd-b6f7b8fccc1f">
