### PR TITLE
Detail page | Genus icons

### DIFF
--- a/app/assets/stylesheets/components/word_header.css
+++ b/app/assets/stylesheets/components/word_header.css
@@ -10,7 +10,7 @@
 
 @media(min-width: 1024px) {
   .word-header {
-    grid-template-columns: auto auto 25%;
+    grid-template-columns: auto 35% 25%;
     grid-template-areas:
     "name properties image"
     "speech properties image";

--- a/app/components/labeled_value_component.html.haml
+++ b/app/components/labeled_value_component.html.haml
@@ -1,3 +1,7 @@
 %div
   = label
-  .font-bold.text-2xl= value
+  .font-bold.text-2xl
+    - if content?
+      = content
+    - else
+      = value

--- a/app/components/labeled_value_component.rb
+++ b/app/components/labeled_value_component.rb
@@ -3,7 +3,7 @@
 class LabeledValueComponent < ViewComponent::Base
   attr_reader :label, :value
 
-  def initialize(label:, value:)
+  def initialize(label:, value: nil)
     @label = label
     @value = value
   end

--- a/app/components/word_header_component.html.haml
+++ b/app/components/word_header_component.html.haml
@@ -3,20 +3,19 @@
     %div= title
     .mt-4.text-lg.md:text-2xl= render SyllablesComponent.new(text: word.syllables)
 
-  %div(style="grid-area: properties")
-    .properties
-      .flex.flex-col.gap-4.justify-center
-        = render LabeledValueComponent.new(label: Word.human_attribute_name(:type), value: word.class.model_name.human)
+  .properties(style="grid-area: properties")
+    .flex.flex-col.gap-4.justify-center
+      = render LabeledValueComponent.new(label: Word.human_attribute_name(:type), value: word.class.model_name.human)
 
-        - properties.each do |property|
-          = property
+      - properties.each do |property|
+        = property
 
-      .w-full.flex.flex-col.gap-4.items-end.lg:items-start
-        - if montessori_symbol.present?
-          = image_tag montessori_symbol, class: "word-symbol"
-        - word.strategies.each do |strategy|
-          - if strategy.fresch_symbol.attached?
-            = image_tag strategy.fresch_symbol, class: "word-symbol"
+    .w-full.flex.flex-col.gap-4.items-end.lg:items-start
+      - if montessori_symbol.present?
+        = image_tag montessori_symbol, class: "word-symbol"
+      - word.strategies.each do |strategy|
+        - if strategy.fresch_symbol.attached?
+          = image_tag strategy.fresch_symbol, class: "word-symbol"
 
   .m-6.max-w-96(style="grid-area: image")
     - if word.image.attached?

--- a/app/models/genus.rb
+++ b/app/models/genus.rb
@@ -1,2 +1,3 @@
 class Genus < ApplicationRecord
+  has_one_attached :symbol
 end

--- a/app/views/nouns/show.html.haml
+++ b/app/views/nouns/show.html.haml
@@ -9,7 +9,11 @@
     - component.with_property do
       = render LabeledValueComponent.new(label: Noun.human_attribute_name(:plural), value: @noun.full_plural)
     - component.with_property do
-      = render LabeledValueComponent.new(label: Noun.human_attribute_name(:genus_id), value: @noun.genus&.name)
+      = render LabeledValueComponent.new(label: Noun.human_attribute_name(:genus_id), value: 'test') do
+        .flex.gap-2.items-center
+          - if @noun.genus&.symbol&.attached?
+            = image_tag @noun.genus.symbol, class: 'max-w-6'
+          = @noun.genus&.name
 
   = render BoxComponent.new(title: t('words.show.properties')) do
     = render BoxGridComponent.new do


### PR DESCRIPTION
Related to #440

Adds genus icons. The icons are attached to the `Genus` model. We don't have the icons yet, but we'll attach them as soon as we have them.

<img width="782" alt="image" src="https://github.com/wort-schule/wort.schule/assets/1394828/6505c11d-77ef-4491-bf7c-35478680133e">
