### PR TITLE
Twitter cards

### DIFF
--- a/app/controllers/concerns/open_graph.rb
+++ b/app/controllers/concerns/open_graph.rb
@@ -6,12 +6,23 @@ module OpenGraph
   def set_open_graph_tags
     return unless resource&.is_a?(Word)
 
-    set_meta_tags og: {
-      title: resource.name,
-      description: resource.meaning_long,
-      url: url_for(resource),
-      image: resource.image.attached? ? url_for(resource.image.variant(:open_graph)) : nil
-    }
+    set_meta_tags(
+      og: {
+        title: resource.name,
+        description: resource.meaning_long,
+        url: url_for(resource),
+        image: resource.image.attached? ? url_for(resource.image.variant(:open_graph)) : nil
+      },
+      twitter: resource.image.attached? ? {
+        card: "summary_large_image",
+        title: resource.name,
+        image: {
+          _: url_for(resource.image.variant(:open_graph)),
+          width: 1200,
+          height: 630
+        }
+      } : nil
+    )
   end
 
   def resource

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -63,7 +63,7 @@ class Word < ApplicationRecord
   has_many_attached :audios
   has_one_attached :image do |attachable|
     attachable.variant :thumb, resize_to_fill: [100, 100], format: :png
-    attachable.variant :open_graph, resize_to_fill: [1080, nil], format: :png
+    attachable.variant :open_graph, resize_to_fill: [1200, 630], format: :png
   end
 
   belongs_to :prefix, optional: true


### PR DESCRIPTION
Closes #301

This adds twitter card meta tags. We already had open graph tags, so most other apps should already have helpful information to render a preview.

It also changes the image size to comply with more modern sizes.