### PR TITLE
Word view settings

### DIFF
--- a/app/components/box_description_list.rb
+++ b/app/components/box_description_list.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class BoxDescriptionList
-  def add(label, content_class = "")
+  def add(label, content_class = "", hide_if_blank: true)
     BoxDescriptionListItemComponent.new(
       label:,
-      content_class:
+      content_class:,
+      hide_if_blank:
     )
   end
 end

--- a/app/components/box_description_list_item_component.rb
+++ b/app/components/box_description_list_item_component.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class BoxDescriptionListItemComponent < ViewComponent::Base
-  def initialize(label:, content_class:)
+  def initialize(label:, content_class:, hide_if_blank: true)
     @label = label
     @content_class = content_class
+    @hide_if_blank = hide_if_blank
   end
 
   def render?
-    return true unless Rails.configuration.hide_blank_items
+    return true if !Rails.configuration.hide_blank_items || !@hide_if_blank
 
     content.present?
   end

--- a/app/controllers/word_view_settings_controller.rb
+++ b/app/controllers/word_view_settings_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class WordViewSettingsController < ApplicationController
+  load_and_authorize_resource
+
+  def index
+    @word_view_settings = @word_view_settings.order(:name).page(params[:page])
+  end
+
+  def show
+  end
+
+  def new
+  end
+
+  def create
+    @word_view_setting.owner = current_user
+
+    if @word_view_setting.save
+      redirect_to @word_view_setting, notice: t("notices.shared.created", name: @word_view_setting.name, class_name: WordViewSetting.model_name.human)
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @word_view_setting.update(word_view_setting_params)
+      redirect_to @word_view_setting, notice: t("notices.shared.updated", name: @word_view_setting.name, class_name: WordViewSetting.model_name.human)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    notice = if @word_view_setting.destroy
+      {notice: t("notices.shared.destroyed", name: @word_view_setting.name, class_name: WordViewSetting.model_name.human)}
+    else
+      {alert: t("alerts.shared.destroyed", name: @word_view_setting.name)}
+    end
+
+    redirect_to word_view_settings_url, notice
+  end
+
+  private
+
+  def word_view_setting_params
+    params.require(:word_view_setting).permit(
+      :name,
+      :visibility,
+      :theme_noun_id,
+      :theme_verb_id,
+      :theme_adjective_id,
+      :theme_function_word_id,
+      :font
+    )
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -31,6 +31,7 @@ class Ability
 
       can :read, Theme, visibility: :public
       can :crud, Theme, {user:}
+      can :read, WordViewSetting, visibility: :public
 
       case user.role
       when "Lecturer"
@@ -54,6 +55,8 @@ class Ability
         can :crud, CompoundVocalalternation
 
         can :read, User
+
+        can :crud, WordViewSetting, owner: user
 
       when "Admin"
         can :manage, Noun
@@ -85,6 +88,7 @@ class Ability
         can :manage, LearningPlea
 
         can :manage, :font
+        can :manage, WordViewSetting
       end
     end
   end

--- a/app/models/word_view_setting.rb
+++ b/app/models/word_view_setting.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class WordViewSetting < ApplicationRecord
+  extend Enumerize
+
+  belongs_to :owner, class_name: "User"
+
+  belongs_to :theme_noun, class_name: "Theme", optional: true
+  belongs_to :theme_verb, class_name: "Theme", optional: true
+  belongs_to :theme_adjective, class_name: "Theme", optional: true
+  belongs_to :theme_function_word, class_name: "Theme", optional: true
+
+  enumerize :visibility, in: %i[private public], default: :private
+
+  validates :name, presence: true
+  validate :public_visibility_only_for_admins
+
+  private
+
+  def public_visibility_only_for_admins
+    if visibility.to_s == "public" && owner.role != "Admin"
+      errors.add(:visibility, :invalid)
+    end
+  end
+end

--- a/app/views/pages/navigation.html.haml
+++ b/app/views/pages/navigation.html.haml
@@ -2,6 +2,7 @@
   %div= navigation_link params[:controller].to_sym == :sources, Source.model_name.human(count: 2), sources_path if can? :read, Source
   %div= navigation_link params[:controller].to_sym == :users, User.model_name.human(count: 2), users_path if can?(:index, User)
   %div= navigation_link params[:controller].to_sym == :learning_groups, LearningGroup.model_name.human(count: 2), learning_groups_path if can?(:index, LearningGroup)
+  = navigation_link params[:controller].to_sym == :word_view_settings, WordViewSetting.model_name.human(count: 2), word_view_settings_path if can?(:index, WordViewSetting)
   = navigation_link false, t('nouns.index.new'), new_noun_path if can?(:create, Noun)
   = navigation_link false, t('verbs.index.new'), new_verb_path if can?(:create, Verb)
   = navigation_link false, t('adjectives.index.new'), new_adjective_path if can?(:create, Adjective)

--- a/app/views/word_view_settings/_form.html.haml
+++ b/app/views/word_view_settings/_form.html.haml
@@ -1,0 +1,15 @@
+= box padding: false do
+  = simple_form_for @word_view_setting do |f|
+    = box_content do
+      = f.input :name, autofocus: true
+      = f.input :font, collection: Fonts.collection, include_blank: t('activerecord.attributes.word_view_setting.no_font')
+      = f.association :theme_noun, include_blank: t('themes.show.standard')
+      = f.association :theme_verb, include_blank: t('themes.show.standard')
+      = f.association :theme_adjective, include_blank: t('themes.show.standard')
+      = f.association :theme_function_word, include_blank: t('themes.show.standard')
+      - if current_user.role.Admin?
+        = f.input :visibility, include_blank: false
+
+    = box_footer do
+      = f.submit
+      = cancel_button @word_view_setting

--- a/app/views/word_view_settings/_word_view_setting.html.haml
+++ b/app/views/word_view_settings/_word_view_setting.html.haml
@@ -1,0 +1,4 @@
+= link_if(can?(:show, word_view_setting), word_view_setting, id: dom_id(word_view_setting)) do
+  = box class: 'h-full' do
+    %div= word_view_setting.name
+    .text-gray-500.text-sm= word_view_setting.owner

--- a/app/views/word_view_settings/edit.html.haml
+++ b/app/views/word_view_settings/edit.html.haml
@@ -1,0 +1,4 @@
+= title_with_actions t('.title') do
+  = button_to t('actions.delete'), @word_view_setting, class: 'button danger', method: :delete, 'data-turbo-confirm': t('confirmations.shared.destroy', name: @word_view_setting.name) if can?(:destroy, @word_view_setting)
+
+= render 'form'

--- a/app/views/word_view_settings/index.html.haml
+++ b/app/views/word_view_settings/index.html.haml
@@ -1,0 +1,8 @@
+= title_with_actions WordViewSetting.model_name.human(count: 2) do
+  - if can? :create, WordViewSetting
+    = link_to t('.new'), new_word_view_setting_path, class: 'button primary'
+
+= index_grid do
+  = render @word_view_settings
+
+= paginate @word_view_settings

--- a/app/views/word_view_settings/new.html.haml
+++ b/app/views/word_view_settings/new.html.haml
@@ -1,0 +1,3 @@
+%h1= t '.title'
+
+= render 'form'

--- a/app/views/word_view_settings/show.html.haml
+++ b/app/views/word_view_settings/show.html.haml
@@ -1,0 +1,31 @@
+= title_with_actions @word_view_setting.name do
+  - if can? :edit, @word_view_setting
+    = link_to t('actions.edit'), edit_word_view_setting_path(@word_view_setting), class: 'button primary'
+
+= two_column_card WordViewSetting.model_name.human, "", first: true do
+  = box padding: false do
+    = box_description_list do |list|
+
+      = render(list.add(WordViewSetting.human_attribute_name(:name))) do
+        = @word_view_setting.name
+
+      = render(list.add(WordViewSetting.human_attribute_name(:owner))) do
+        = @word_view_setting.owner
+
+      = render(list.add(WordViewSetting.human_attribute_name(:font), "", hide_if_blank: false)) do
+        = Fonts.by_key(@word_view_setting.font)&.name
+
+      = render(list.add(WordViewSetting.human_attribute_name(:theme_noun), "", hide_if_blank: false)) do
+        = @word_view_setting.theme_noun&.name
+
+      = render(list.add(WordViewSetting.human_attribute_name(:theme_verb), "", hide_if_blank: false)) do
+        = @word_view_setting.theme_verb&.name
+
+      = render(list.add(WordViewSetting.human_attribute_name(:theme_adjective), "", hide_if_blank: false)) do
+        = @word_view_setting.theme_adjective&.name
+
+      = render(list.add(WordViewSetting.human_attribute_name(:theme_function_word), "", hide_if_blank: false)) do
+        = @word_view_setting.theme_function_word&.name
+
+      = render(list.add(WordViewSetting.human_attribute_name(:visibility))) do
+        = @word_view_setting.visibility_text

--- a/config/locales/enumerize.de.yml
+++ b/config/locales/enumerize.de.yml
@@ -23,3 +23,7 @@ de:
       visibility:
         private: Privat
         public: Öffentlich
+    word_view_setting:
+      visibility:
+        private: Privat
+        public: Öffentlich

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -67,6 +67,9 @@ de:
       list:
         one: Wortliste
         other: Wortlisten
+      word_view_setting:
+        one: Ansichtseinstellung
+        other: Ansichtseinstellungen
 
     attributes:
       user:
@@ -226,3 +229,13 @@ de:
           5: Fach 5
       learning_group_membership:
         user: E-Mail Adresse oder Benutzername
+      word_view_setting:
+        name: Bezeichnung
+        owner: Benutzer*in
+        theme_noun: Theme für Substantive
+        theme_verb: Theme für Verben
+        theme_adjective: Theme für Adjektive
+        theme_function_word: Theme für Funktionswörter
+        font: Schrift
+        no_font: Standardschrift
+        visibility: Sichtbarkeit

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -275,6 +275,13 @@ de:
       move_word_to_next_section: ins nächste Fach schieben
       show_word: Wort anzeigen
       show_actions: Aktionen anzeigen
+  word_view_settings:
+    index:
+      new: Neue Wort-Ansichtseinstellung
+    new:
+      title: Wort-Ansichtseinstellung erstellen
+    edit:
+      title: Wort-Ansichtseinstellung bearbeiten
   shared:
     versions:
       title: Änderungshistorie

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
     end
     post :list_add_word, to: "lists#add_word"
     resources :flashcards, only: :index
+    resources :word_view_settings
 
     # User's own routes
     resource :profile, only: %i[show edit update] do

--- a/db/migrate/20240615153651_create_word_view_settings.rb
+++ b/db/migrate/20240615153651_create_word_view_settings.rb
@@ -1,0 +1,16 @@
+class CreateWordViewSettings < ActiveRecord::Migration[7.1]
+  def change
+    create_table :word_view_settings do |t|
+      t.string :name, null: false
+      t.string :font
+      t.string :visibility, default: "private"
+      t.references :owner, null: false, foreign_key: {to_table: :users}
+      t.references :theme_noun, null: true, foreign_key: {to_table: :themes}
+      t.references :theme_verb, null: true, foreign_key: {to_table: :themes}
+      t.references :theme_adjective, null: true, foreign_key: {to_table: :themes}
+      t.references :theme_function_word, null: true, foreign_key: {to_table: :themes}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_31_161042) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_15_153651) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pgcrypto"
@@ -390,6 +390,24 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_31_161042) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  create_table "word_view_settings", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "font"
+    t.string "visibility", default: "private"
+    t.bigint "owner_id", null: false
+    t.bigint "theme_noun_id"
+    t.bigint "theme_verb_id"
+    t.bigint "theme_adjective_id"
+    t.bigint "theme_function_word_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["owner_id"], name: "index_word_view_settings_on_owner_id"
+    t.index ["theme_adjective_id"], name: "index_word_view_settings_on_theme_adjective_id"
+    t.index ["theme_function_word_id"], name: "index_word_view_settings_on_theme_function_word_id"
+    t.index ["theme_noun_id"], name: "index_word_view_settings_on_theme_noun_id"
+    t.index ["theme_verb_id"], name: "index_word_view_settings_on_theme_verb_id"
+  end
+
   create_table "words", force: :cascade do |t|
     t.bigint "hierarchy_id"
     t.datetime "created_at", null: false
@@ -481,6 +499,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_31_161042) do
   add_foreign_key "users", "themes", column: "theme_function_word_id"
   add_foreign_key "users", "themes", column: "theme_noun_id"
   add_foreign_key "users", "themes", column: "theme_verb_id"
+  add_foreign_key "word_view_settings", "themes", column: "theme_adjective_id"
+  add_foreign_key "word_view_settings", "themes", column: "theme_function_word_id"
+  add_foreign_key "word_view_settings", "themes", column: "theme_noun_id"
+  add_foreign_key "word_view_settings", "themes", column: "theme_verb_id"
+  add_foreign_key "word_view_settings", "users", column: "owner_id"
   add_foreign_key "words", "hierarchies"
   add_foreign_key "words", "postfixes"
   add_foreign_key "words", "prefixes"

--- a/spec/factories/word_view_settings.rb
+++ b/spec/factories/word_view_settings.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :word_view_setting do
+    name { Faker::Team.name }
+    association :owner, factory: :user
+  end
+end

--- a/spec/features/word_view_settings_spec.rb
+++ b/spec/features/word_view_settings_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe "word view settings" do
+  it_behaves_like "CRUD", WordViewSetting
+
+  let!(:admin) { create(:user, role: "Admin") }
+  let!(:lecturer) { create(:user, role: "Lecturer") }
+  let!(:public_word_view_setting) { create(:word_view_setting, owner: admin, visibility: :public) }
+  let!(:private_word_view_setting_of_admin) { create(:word_view_setting, owner: admin, visibility: :private) }
+  let!(:private_word_view_setting_of_lecturer) { create(:word_view_setting, owner: lecturer, visibility: :private) }
+
+  context "as an admin" do
+    before { login_as admin }
+
+    it "shows private word view settings from other users" do
+      visit word_view_settings_path
+
+      expect(page).to have_content public_word_view_setting.name
+      expect(page).to have_content private_word_view_setting_of_admin.name
+      expect(page).to have_content private_word_view_setting_of_lecturer.name
+    end
+  end
+
+  context "as a lecturer" do
+    before { login_as lecturer }
+
+    it "shows only my own private word view settings" do
+      visit word_view_settings_path
+
+      expect(page).to have_content public_word_view_setting.name
+      expect(page).not_to have_content private_word_view_setting_of_admin.name
+      expect(page).to have_content private_word_view_setting_of_lecturer.name
+    end
+  end
+end


### PR DESCRIPTION
Related to #440.

This adds a `WordViewSetting` model and CRUD for it. It will later be used to steer the view of words. Such as, shall we display syllable arcs or not.

The model is currently not yet used. This PR only adds CRUD for it.

![screengrab-20240615-1856](https://github.com/wort-schule/wort.schule/assets/1394828/d484a549-12d5-4fc8-9a81-7a6ee689b645)
