### PR TITLE
Add different wording for word types and genus

### DIFF
--- a/app/components/word_header_component.html.haml
+++ b/app/components/word_header_component.html.haml
@@ -5,7 +5,7 @@
 
   .properties(style="grid-area: properties")
     .flex.flex-col.gap-4.justify-center
-      = render LabeledValueComponent.new(label: Word.human_attribute_name(:type), value: word.class.model_name.human)
+      = render LabeledValueComponent.new(label: Word.human_attribute_name(:type), value: WordTypes.label(helpers.current_word_view_setting.word_type_wording, word.class.model_name.name))
 
       - properties.each do |property|
         = property

--- a/app/controllers/word_view_settings_controller.rb
+++ b/app/controllers/word_view_settings_controller.rb
@@ -61,7 +61,9 @@ class WordViewSettingsController < ApplicationController
       :show_horizontal_lines,
       :show_montessori_symbols,
       :show_fresch_symbols,
-      :show_gender_symbols
+      :show_gender_symbols,
+      :word_type_wording,
+      :genus_wording
     )
   end
 end

--- a/app/models/genus.rb
+++ b/app/models/genus.rb
@@ -1,3 +1,38 @@
 class Genus < ApplicationRecord
   has_one_attached :symbol
+
+  NAMES = {
+    foreign: {
+      masculinum: "Maskulinum",
+      femininum: "Femininum",
+      neutrum: "Neutrum"
+    },
+    german: {
+      masculinum: "männlich",
+      femininum: "weiblich",
+      neutrum: "sächlich"
+    }
+  }.freeze
+
+  def self.keys
+    NAMES.keys
+  end
+
+  def self.as_collection
+    NAMES.map do |key, names|
+      label = names.values.join(" — ")
+
+      [label, key]
+    end
+  end
+
+  def self.label_all(key)
+    NAMES[key.to_sym].values.join(" — ")
+  end
+
+  def label(key)
+    genus_keys.map do |genus_key|
+      NAMES[key.to_sym][genus_key.to_sym]
+    end.join("/")
+  end
 end

--- a/app/models/word_view_setting.rb
+++ b/app/models/word_view_setting.rb
@@ -13,6 +13,8 @@ class WordViewSetting < ApplicationRecord
   has_many :learning_groups
 
   enumerize :visibility, in: %i[private public], default: :private
+  enumerize :word_type_wording, in: WordTypes.keys, default: WordTypes.keys.first
+  enumerize :genus_wording, in: Genus.keys, default: Genus.keys.first
 
   validates :name, presence: true
   validate :public_visibility_only_for_admins

--- a/app/services/word_types.rb
+++ b/app/services/word_types.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class WordTypes
+  NAMES = [
+    {
+      key: "default",
+      names: {
+        "Noun" => ["Nomen", "Nomen"],
+        "Verb" => ["Verb", "Verben"],
+        "Adjective" => ["Adjektiv", "Adjektive"],
+        "FunctionWord" => ["Funktionswort", "Funktionswörter"]
+      }
+    },
+    {
+      key: "sub",
+      names: {
+        "Noun" => ["Substantiv", "Substantive"],
+        "Verb" => ["Verb", "Verben"],
+        "Adjective" => ["Adjektiv", "Adjektive"],
+        "FunctionWord" => ["Funktionswort", "Funktionswörter"]
+      }
+    },
+    {
+      key: "german",
+      names: {
+        "Noun" => ["Namenwort", "Namenwörter"],
+        "Verb" => ["Tu-Wort", "Tu-Wörter"],
+        "Adjective" => ["wie-Wort", "wie-Wörter"],
+        "FunctionWord" => ["Funktionswort", "Funktionswörter"]
+      }
+    }
+  ].freeze
+
+  def self.label(key, word_type)
+    NAMES
+      .find { |names| names[:key] == key }
+      &.dig(:names, word_type, 0)
+  end
+
+  def self.keys
+    as_collection.map(&:second)
+  end
+
+  def self.as_collection
+    NAMES
+      .map do |config|
+        key = config[:key]
+        label = config[:names].values.map(&:first).join(" — ")
+
+        [label, key]
+      end
+  end
+
+  def self.label_all(key)
+    config = NAMES.find { |names| names[:key] == key }
+
+    config[:names].values.map(&:first).join(" — ")
+  end
+end

--- a/app/views/nouns/show.html.haml
+++ b/app/views/nouns/show.html.haml
@@ -13,7 +13,7 @@
         .flex.gap-2.items-center
           - if @noun.genus&.symbol&.attached? && current_word_view_setting.show_gender_symbols
             = image_tag @noun.genus.symbol, class: 'max-w-6'
-          = @noun.genus&.name
+          = @noun.genus&.label(current_word_view_setting.genus_wording)
 
   = render BoxComponent.new(title: t('words.show.properties')) do
     = render BoxGridComponent.new do

--- a/app/views/word_view_settings/_form.html.haml
+++ b/app/views/word_view_settings/_form.html.haml
@@ -14,6 +14,8 @@
       = f.input :show_montessori_symbols
       = f.input :show_fresch_symbols
       = f.input :show_gender_symbols
+      = f.input :word_type_wording, collection: WordTypes.as_collection, include_blank: false
+      = f.input :genus_wording, collection: Genus.as_collection, include_blank: false
       - if current_user.role.Admin?
         = f.input :visibility, include_blank: false
 

--- a/app/views/word_view_settings/show.html.haml
+++ b/app/views/word_view_settings/show.html.haml
@@ -48,6 +48,12 @@
       = render(list.add(WordViewSetting.human_attribute_name(:show_gender_symbols), "", hide_if_blank: false)) do
         = @word_view_setting.show_gender_symbols.humanize
 
+      = render(list.add(WordViewSetting.human_attribute_name(:word_type_wording), "", hide_if_blank: false)) do
+        = WordTypes.label_all(@word_view_setting.word_type_wording)
+
+      = render(list.add(WordViewSetting.human_attribute_name(:genus_wording), "", hide_if_blank: false)) do
+        = Genus.label_all(@word_view_setting.genus_wording)
+
       = render(list.add(WordViewSetting.human_attribute_name(:visibility))) do
         = @word_view_setting.visibility_text
 

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -238,5 +238,7 @@ de:
         show_montessori_symbols: Montessori Symbole anzeigen
         show_fresch_symbols: Fresch Symbole anzeigen
         show_gender_symbols: Symbole für Wortgeschlecht anzeigen
+        word_type_wording: Bezeichnung Worttypen
+        genus_wording: Bezeichnung Wortgeschlechter
         no_font: Standardschrift
         visibility: Sichtbarkeit

--- a/db/migrate/20240616152222_add_wording_to_word_view_settings.rb
+++ b/db/migrate/20240616152222_add_wording_to_word_view_settings.rb
@@ -1,0 +1,18 @@
+class AddWordingToWordViewSettings < ActiveRecord::Migration[7.1]
+  def change
+    add_column :word_view_settings, :word_type_wording, :string, null: false, default: 'default'
+    add_column :word_view_settings, :genus_wording, :string, null: false, default: 'default'
+    add_column :genus, :genus_keys, :string, array: true, default: []
+
+    reversible do |direction|
+      direction.up do
+        Genus.find_each do |genus|
+          genus.genus_keys << :masculinum if genus.name.include?('Maskulinum')
+          genus.genus_keys << :femininum if genus.name.include?('Femininum')
+          genus.genus_keys << :neutrum if genus.name.include?('Neutrum')
+          genus.save!
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_16_133652) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_16_152222) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pgcrypto"
@@ -91,6 +91,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_16_133652) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "genus_keys", default: [], array: true
   end
 
   create_table "good_job_batches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -395,6 +396,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_16_133652) do
     t.boolean "show_montessori_symbols", default: true, null: false
     t.boolean "show_fresch_symbols", default: true, null: false
     t.boolean "show_gender_symbols", default: true, null: false
+    t.string "word_type_wording", default: "default", null: false
+    t.string "genus_wording", default: "default", null: false
     t.index ["owner_id"], name: "index_word_view_settings_on_owner_id"
     t.index ["theme_adjective_id"], name: "index_word_view_settings_on_theme_adjective_id"
     t.index ["theme_function_word_id"], name: "index_word_view_settings_on_theme_function_word_id"


### PR DESCRIPTION
Related to #440

This adds different wording for word types and genus.

These can be selected as view settings:

<img width="504" alt="image" src="https://github.com/wort-schule/wort.schule/assets/1394828/d98b728c-77a1-4ddd-b810-e6b82b331375">

They are then reflected when rendering the word:

<img width="558" alt="image" src="https://github.com/wort-schule/wort.schule/assets/1394828/7d60d2e7-ea8d-4778-9ade-285bf5e65a59">
