### PR TITLE
Fix missing `erb` helper in production

### DIFF
--- a/app/views/themes/default_adjective.liquid
+++ b/app/views/themes/default_adjective.liquid
@@ -12,10 +12,10 @@
     {% endbox_grid %}
   {% endbox %}
 
-  <%= erb Rails.root.join('app/views/themes/liquid/meaning.liquid') %>
-  <%= erb Rails.root.join('app/views/themes/liquid/syntax.liquid') %>
+  <%= ERB.new(File.read(Rails.root.join('app/views/themes/liquid/meaning.liquid'))).result %>
+  <%= ERB.new(File.read(Rails.root.join('app/views/themes/liquid/syntax.liquid'))).result %>
   {{ lists_box }}
   {{ example_sentences_box }}
   {{ other_meanings_box }}
-  <%= erb Rails.root.join('app/views/themes/liquid/relations.liquid') %>
+  <%= ERB.new(File.read(Rails.root.join('app/views/themes/liquid/relations.liquid'))).result %>
 </div>

--- a/app/views/themes/default_noun.liquid
+++ b/app/views/themes/default_noun.liquid
@@ -11,7 +11,7 @@
     {% endbox_grid %}
   {% endbox %}
 
-  <%= erb Rails.root.join('app/views/themes/liquid/meaning.liquid') %>
+  <%= ERB.new(File.read(Rails.root.join('app/views/themes/liquid/meaning.liquid'))).result.html_safe %>
 
   {% if case_1_singular != blank || case_1_plural != blank || case_2_singular != blank || case_2_plural != blank || case_3_singular != blank || case_3_plural != blank || case_4_singular != blank || case_4_plural != blank %}
     {% box Fälle / Kasus %}
@@ -95,9 +95,9 @@
     {% endbox %}
   {% endif %}
 
-  <%= erb Rails.root.join('app/views/themes/liquid/syntax.liquid') %>
+  <%= ERB.new(File.read(Rails.root.join('app/views/themes/liquid/syntax.liquid'))).result.html_safe %>
   {{ lists_box }}
   {{ example_sentences_box }}
   {{ other_meanings_box }}
-  <%= erb Rails.root.join('app/views/themes/liquid/relations.liquid') %>
+  <%= ERB.new(File.read(Rails.root.join('app/views/themes/liquid/relations.liquid'))).result.html_safe %>
 </div>

--- a/app/views/themes/default_verb.liquid
+++ b/app/views/themes/default_verb.liquid
@@ -9,7 +9,7 @@
     {% endbox_grid %}
   {% endbox %}
 
-  <%= erb Rails.root.join('app/views/themes/liquid/meaning.liquid') %>
+  <%= ERB.new(File.read(Rails.root.join('app/views/themes/liquid/meaning.liquid'))).result %>
 
   {% box Formen %}
     {% box_grid 3 %}
@@ -83,9 +83,9 @@
     {% endbox %}
   {% endif %}
 
-  <%= erb Rails.root.join('app/views/themes/liquid/syntax.liquid') %>
+  <%= ERB.new(File.read(Rails.root.join('app/views/themes/liquid/syntax.liquid'))).result %>
   {{ lists_box }}
   {{ example_sentences_box }}
   {{ other_meanings_box }}
-  <%= erb Rails.root.join('app/views/themes/liquid/relations.liquid') %>
+  <%= ERB.new(File.read(Rails.root.join('app/views/themes/liquid/relations.liquid'))).result %>
 </div>


### PR DESCRIPTION
Closes #493.

Fixes the display of the "show" views. Already deployed the branch so the words are shown correctly again.

My bad: I believed to remember that there is an `erb` helper to render ERB files (in truth that only exists in Sinatra). And yes, that worked in development, but not in production.

Turns out, Mina has defined a helper `erb`, doing what I expect it to do. They extend that helper onto `Object`, so that was magically available everywhere. As we don't load that helper in production, the method was missing.