### PR TITLE
Hierarchy list

### DIFF
--- a/app/controllers/hierarchies_controller.rb
+++ b/app/controllers/hierarchies_controller.rb
@@ -44,6 +44,12 @@ class HierarchiesController < ApplicationController
     redirect_to hierarchies_url, notice
   end
 
+  def remove_image
+    @hierarchy.image.purge if @hierarchy.image.attached?
+
+    redirect_to @hierarchy
+  end
+
   private
 
   def hierarchy_params

--- a/app/controllers/hierarchies_controller.rb
+++ b/app/controllers/hierarchies_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class HierarchiesController < ApplicationController
+class HierarchiesController < PublicController
   load_and_authorize_resource
 
   def index

--- a/app/controllers/hierarchies_controller.rb
+++ b/app/controllers/hierarchies_controller.rb
@@ -48,7 +48,7 @@ class HierarchiesController < ApplicationController
 
   def hierarchy_params
     params.require(:hierarchy).permit(
-      :name, :top_hierarchy_id
+      :name, :top_hierarchy_id, :image
     )
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -13,6 +13,7 @@ class Ability
     can :read, List, visibility: :public
     can :read, Source, visible: true
     can :read, Keyword
+    can :read, Hierarchy
 
     if user.present?
       can %i[show edit update destroy], User, %i[first_name last_name avatar email password word_view_setting_id], id: user.id

--- a/app/models/hierarchy.rb
+++ b/app/models/hierarchy.rb
@@ -5,5 +5,10 @@ class Hierarchy < ApplicationRecord
   has_many :children, class_name: "Hierarchy", foreign_key: "top_hierarchy_id"
   has_many :words
 
+  has_one_attached :image do |attachable|
+    attachable.variant :thumb, resize_to_fill: [100, 100], format: :png
+    attachable.variant :open_graph, resize_to_fill: [1200, 630], format: :png
+  end
+
   validates_presence_of :name
 end

--- a/app/views/hierarchies/_form.html.haml
+++ b/app/views/hierarchies/_form.html.haml
@@ -2,6 +2,7 @@
   = simple_form_for @hierarchy do |f|
     = box_content do
       = f.input :name, autofocus: true
+      = f.input :image
       = f.association :parent
 
     = box_footer do

--- a/app/views/hierarchies/_hierarchy.html.haml
+++ b/app/views/hierarchies/_hierarchy.html.haml
@@ -1,4 +1,4 @@
-= link_if(can?(:show, hierarchy), hierarchy, id: dom_id(hierarchy)) do
+= link_if(can?(:show, hierarchy), hierarchy, id: dom_id(hierarchy), data: {turbo_frame: '_top'}) do
   = box padding: false, class: 'h-full' do
     .flex.justify-between.h-full
       .px-4.py-5.sm:px-6

--- a/app/views/hierarchies/_hierarchy.html.haml
+++ b/app/views/hierarchies/_hierarchy.html.haml
@@ -1,3 +1,13 @@
 = link_if(can?(:show, hierarchy), hierarchy, id: dom_id(hierarchy)) do
-  = box class: 'h-full' do
-    = hierarchy.name
+  = box padding: false, class: 'h-full' do
+    .flex.justify-between.h-full
+      .px-4.py-5.sm:px-6
+        .flex.items-baseline.gap-1
+          .text-xl.font-bold= hierarchy.name
+        .text-xs.font-light.mt-3= t('.words_count', count: hierarchy.words.count)
+
+      .p-1.pr-4.flex.items-center.object-cover
+        - if hierarchy.image.attached?
+          = image_tag hierarchy.image.variant(:thumb), class: 'w-24 h-full object-cover'
+        - else
+          .w-24.h-24

--- a/app/views/hierarchies/show.html.haml
+++ b/app/views/hierarchies/show.html.haml
@@ -14,6 +14,7 @@
         .flex.flex-wrap
           - if @hierarchy.image.attached?
             = image_tag @hierarchy.image
+            = button_to t('actions.delete'), remove_image_hierarchy_path(@hierarchy), method: :delete
 
 = render 'words/usages'
 

--- a/app/views/hierarchies/show.html.haml
+++ b/app/views/hierarchies/show.html.haml
@@ -10,6 +10,11 @@
       = render(list.add(Hierarchy.human_attribute_name(:parent))) do
         .flex.flex-wrap= hierarchy_breadcrumbs @hierarchy.parent
 
+      = render(list.add(Hierarchy.human_attribute_name(:image))) do
+        .flex.flex-wrap
+          - if @hierarchy.image.attached?
+            = image_tag @hierarchy.image
+
 = render 'words/usages'
 
 .pagination-with-actions

--- a/app/views/hierarchies/show.html.haml
+++ b/app/views/hierarchies/show.html.haml
@@ -1,23 +1,38 @@
-= title_with_actions @hierarchy.name
+.mb-4= link_to t('.back'), hierarchies_path
 
-= two_column_card Hierarchy.model_name.human, "", first: true do
-  = box padding: false do
-    = box_description_list do |list|
+= box padding: false, class: 'h-full' do
+  .flex.justify-between.h-full
+    .px-4.py-5.sm:px-6
+      .flex.flex-wrap= hierarchy_breadcrumbs @hierarchy.parent
+      .text-xl.font-bold= @hierarchy.name
 
-      = render(list.add(Hierarchy.human_attribute_name(:name))) do
-        = @hierarchy.name
-    
-      = render(list.add(Hierarchy.human_attribute_name(:parent))) do
-        .flex.flex-wrap= hierarchy_breadcrumbs @hierarchy.parent
-
-      = render(list.add(Hierarchy.human_attribute_name(:image))) do
-        .flex.flex-wrap
-          - if @hierarchy.image.attached?
-            = image_tag @hierarchy.image
+    .p-1.pr-4.flex.items-center.object-cover
+      - if @hierarchy.image.attached?
+        .flex.flex-col
+          = image_tag @hierarchy.image.variant(:thumb), class: 'w-24 h-full object-cover'
+          - if can? :remove_image, @hierarchy
             = button_to t('actions.delete'), remove_image_hierarchy_path(@hierarchy), method: :delete
+      - else
+        .w-24.h-24
 
-= render 'words/usages'
+= turbo_frame_tag :children do
+  - if @hierarchy.children.present?
+    %h1= t '.children.title'
+    .grid.my-6.gap-4.grid-cols-1.lg:grid-cols-2.xl:grid-cols-3
+      = render @hierarchy.children.page(params[:page])
+
+    .pagination-with-actions
+      = paginate @hierarchy.children.page(params[:page])
+
+= turbo_frame_tag :words do
+  %h1= t '.words.title'
+  .grid.my-6.gap-4.grid-cols-1.lg:grid-cols-2.xl:grid-cols-3
+    - @hierarchy.words.each do |word|
+      = render WordPanelComponent.new(word:)
+
+  .pagination-with-actions
+    = paginate @words
 
 - if can? :edit, @hierarchy
-  .pagination-with-actions
+  .pagination-with-actions.mt-4
     = link_to t('actions.edit'), edit_hierarchy_path(@hierarchy), class: 'button primary'

--- a/app/views/hierarchies/show.html.haml
+++ b/app/views/hierarchies/show.html.haml
@@ -18,5 +18,6 @@
 
 = render 'words/usages'
 
-.pagination-with-actions
-  = link_to t('actions.edit'), edit_hierarchy_path(@hierarchy), class: 'button primary'
+- if can? :edit, @hierarchy
+  .pagination-with-actions
+    = link_to t('actions.edit'), edit_hierarchy_path(@hierarchy), class: 'button primary'

--- a/app/views/pages/navigation.html.haml
+++ b/app/views/pages/navigation.html.haml
@@ -7,8 +7,9 @@
   = navigation_link false, t('verbs.index.new'), new_verb_path if can?(:create, Verb)
   = navigation_link false, t('adjectives.index.new'), new_adjective_path if can?(:create, Adjective)
   = navigation_link false, Keyword.model_name.human(count: 2), keywords_path
+  = navigation_link false, Hierarchy.model_name.human(count: 2), hierarchies_path
 
-  - if [FunctionWord, Topic, Hierarchy, Prefix, Postfix, Phenomenon, Strategy, CompoundInterfix, CompoundPreconfix, CompoundPostconfix, CompoundPhonemreduction, CompoundVocalalternation].any? { |klass| can? :read, klass }
+  - if [FunctionWord, Topic, Prefix, Postfix, Phenomenon, Strategy, CompoundInterfix, CompoundPreconfix, CompoundPostconfix, CompoundPhonemreduction, CompoundVocalalternation].any? { |klass| can? :read, klass }
     .text-gray-300.hover:bg-primary-hover.hover:text-white.px-3.py-2.rounded-md.text-sm.font-medium
       .relative(data-controller="dropdown reveal")
         .inline-block.select-none(data-action="click->dropdown#toggle click@window->dropdown#hide click->reveal#toggle" role="button" data-dropdown-target="button" tabindex="0")
@@ -21,7 +22,6 @@
           .md:bg-primary-hover.md:shadow.rounded-md.md:border.md:border-primary-hover.overflow-hidden
             = dropdown_link FunctionWord
             = dropdown_link Topic
-            = dropdown_link Hierarchy
             = dropdown_link Prefix
             = dropdown_link Postfix
             = dropdown_link Phenomenon

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -144,6 +144,7 @@ de:
       hierarchy:
         name: Bezeichnung
         parent: Übergeordnete Kategorie
+        image: Bild
       prefix:
         name: Bezeichnung
         prefix_type: Typ

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -142,6 +142,10 @@ de:
       title: Neue Kategorie
     edit:
       title: Kategorie bearbeiten
+    hierarchy:
+      words_count:
+        one: "%{count} Wort"
+        other: "%{count} Wörter"
   prefixes:
     index:
       new: Neue Vorsilbe

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -138,6 +138,12 @@ de:
   hierarchies:
     index:
       new: Neue Kategorie
+    show:
+      back: '← Zurück zu allen Kategorien'
+      children:
+        title: Unterkategorien
+      words:
+        title: Wörter
     new:
       title: Neue Kategorie
     edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,9 @@ Rails.application.routes.draw do
     resources :sources
     resources :function_words, only: %i[index new create]
     resources :topics
-    resources :hierarchies
+    resources :hierarchies do
+      delete :remove_image, on: :member
+    end
     resources :prefixes
     resources :postfixes
     resources :phenomenons


### PR DESCRIPTION
Closes #492.

Changes the existing hierarchy views to be publicly available. Also adds images to hierarchies.

![screengrab-20240630-1515](https://github.com/wort-schule/wort.schule/assets/1394828/348044a8-6318-49f1-be55-3395dc6975c3)