### PR TITLE
Fix display after saving word

### DIFF
--- a/app/views/adjectives/_form.html.haml
+++ b/app/views/adjectives/_form.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for @adjective, html: {data: {controller: 'nested-form', nested_form_wrapper_selector_value: '.nested-form-wrapper'}} do |f|
+= simple_form_for @adjective, html: {data: {controller: 'nested-form', nested_form_wrapper_selector_value: '.nested-form-wrapper', turbo: false}} do |f|
   = two_column_card t('words.show.adjective.title'), t('words.show.adjective.description'), first: true do
     = box padding: false do
       = box_content do

--- a/app/views/function_words/_form.html.haml
+++ b/app/views/function_words/_form.html.haml
@@ -1,5 +1,5 @@
 = box padding: false do
-  = simple_form_for @function_word do |f|
+  = simple_form_for @function_word, html: {'data-turbo': false} do |f|
     = box_content do
       = f.input :name, autofocus: true, label: Word.human_attribute_name(:name)
       = f.input :function_type, collection: FunctionWord.function_types_collection, include_blank: false

--- a/app/views/nouns/_form.html.haml
+++ b/app/views/nouns/_form.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for @noun, html: {data: {controller: 'nested-form', nested_form_wrapper_selector_value: '.nested-form-wrapper'}} do |f|
+= simple_form_for @noun, html: {data: {controller: 'nested-form', nested_form_wrapper_selector_value: '.nested-form-wrapper', turbo: false}} do |f|
   = two_column_card t('words.show.noun.title'), t('words.show.noun.description') do
     = box do
       = f.input :name

--- a/app/views/verbs/_form.html.haml
+++ b/app/views/verbs/_form.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for @verb, html: {data: {controller: 'nested-form', nested_form_wrapper_selector_value: '.nested-form-wrapper'}} do |f|
+= simple_form_for @verb, html: {data: {controller: 'nested-form', nested_form_wrapper_selector_value: '.nested-form-wrapper', turbo: false}} do |f|
   = two_column_card t('words.show.verb.title'), t('words.show.verb.description'), first: true do
     = box padding: false do
       = box_content do


### PR DESCRIPTION
Related to #440

This fixes the display after saving a word. Previously, the form did not disappear and was overlapped with the show view.