### PR TITLE
Wording | Word types

### DIFF
--- a/app/components/word_type_filter_component.rb
+++ b/app/components/word_type_filter_component.rb
@@ -3,12 +3,13 @@
 class WordTypeFilterComponent < ViewComponent::Base
   with_collection_parameter :word_type
 
-  attr_reader :word_type, :counts, :current_word_type
+  attr_reader :word_type, :counts, :current_word_type, :current_word_type_wording
 
-  def initialize(word_type:, counts:, current_word_type:)
+  def initialize(word_type:, counts:, current_word_type:, current_word_type_wording:)
     @word_type = word_type
     @counts = counts
     @current_word_type = current_word_type.to_s
+    @current_word_type_wording = current_word_type_wording
   end
 
   def label
@@ -16,7 +17,13 @@ class WordTypeFilterComponent < ViewComponent::Base
     when :all
       t("filter.results.all", count: formatted_count)
     else
-      t("filter.results.#{word_type.model_name.plural}", count: formatted_count)
+      word_type_label = WordTypes.label(
+        current_word_type_wording,
+        word_type.model_name.name,
+        plural: count != 1
+      )
+
+      t("filter.results.word_type", word_type: word_type_label, count: formatted_count)
     end
   end
 

--- a/app/helpers/word_view_settings_helper.rb
+++ b/app/helpers/word_view_settings_helper.rb
@@ -30,4 +30,11 @@ module WordViewSettingsHelper
     session[:word_view_setting_id] = word_view_setting&.id
     current_user&.update(word_view_setting:)
   end
+
+  def word_type_wording_for(klass)
+    WordTypes.label(
+      current_word_view_setting.word_type_wording,
+      klass.model_name.name
+    )
+  end
 end

--- a/app/services/word_types.rb
+++ b/app/services/word_types.rb
@@ -31,10 +31,10 @@ class WordTypes
     }
   ].freeze
 
-  def self.label(key, word_type)
+  def self.label(key, word_type, plural: false)
     NAMES
       .find { |names| names[:key] == key }
-      &.dig(:names, word_type, 0)
+      &.dig(:names, word_type, plural ? 1 : 0)
   end
 
   def self.keys

--- a/app/views/homes/_search_result.html.haml
+++ b/app/views/homes/_search_result.html.haml
@@ -8,4 +8,4 @@
     .py-2.flex.items-baseline.font-bold
       = render HighlightedSearchResultComponent.new(result: word, query: params.dig(:filterrific, :filter_home))
 
-  .uppercase.text-xs.py-2= word.model_name.human
+  .uppercase.text-xs.py-2= word_type_wording_for(word.class)

--- a/app/views/searches/_word_type_filter.html.haml
+++ b/app/views/searches/_word_type_filter.html.haml
@@ -1,2 +1,2 @@
 .px-6.mt-12.flex.flex-row.flex-wrap.md:justify-center.gap-2.md:gap-8.tabbed-radio-buttons
-  = render WordTypeFilterComponent.with_collection([:all, Noun, Verb, Adjective, FunctionWord], counts: @counts, current_word_type: @filter_type)
+  = render WordTypeFilterComponent.with_collection([:all, Noun, Verb, Adjective, FunctionWord], counts: @counts, current_word_type: @filter_type, current_word_type_wording: current_word_view_setting.word_type_wording)

--- a/config/locales/filter.de.yml
+++ b/config/locales/filter.de.yml
@@ -53,15 +53,4 @@ de:
       all:
         one: 'Ergebnis (%{count})'
         other: 'Alle Ergebnisse (%{count})'
-      nouns:
-        one: 'Substantiv (%{count})'
-        other: 'Substantive (%{count})'
-      verbs:
-        one: 'Verb (%{count})'
-        other: 'Verben (%{count})'
-      adjectives:
-        one: 'Adjektiv (%{count})'
-        other: 'Adjektive (%{count})'
-      function_words:
-        one: 'Funktionswort (%{count})'
-        other: 'Funktionswörter (%{count})'
+      word_type: '%{word_type} (%{count})'

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "word filter" do
       expect(page).to have_content "abbauen"
       expect(page).to have_content "abstrakt"
 
-      find(:label, text: t("filter.results.nouns.other", count: 1)).click
+      find(:label, text: t("filter.results.word_type", word_type: "Nomen", count: 1)).click
       find_button(t("filter.apply"), visible: false).trigger("click")
 
       expect(page).not_to have_content "abbauen"


### PR DESCRIPTION
Closes #495.

This changes the wording of word types to the configured ones, also in the search:

<img width="505" alt="image" src="https://github.com/wort-schule/wort.schule/assets/1394828/fff7c86b-9cc2-49d4-81af-4693381039d0">

<img width="863" alt="image" src="https://github.com/wort-schule/wort.schule/assets/1394828/890b4d00-aa05-495f-ab85-01240126091e">
