### PR TITLE
Filter | Empty syllables

### DIFF
--- a/app/controllers/concerns/word_filter.rb
+++ b/app/controllers/concerns/word_filter.rb
@@ -80,7 +80,8 @@ module WordFilter
         :filter_irregular_comparison,
         :filter_images,
         :filter_letter_count,
-        :filter_syllables_count
+        :filter_syllables_count,
+        :filter_syllables_empty
       ]
     )
 
@@ -168,6 +169,10 @@ module WordFilter
       return if query.blank?
 
       where("regexp_replace(words.syllables, '\s', '', 'g') != '' AND array_length(regexp_split_to_array(words.syllables, '-'), 1) = ?", query)
+    }
+
+    scope :filter_syllables_empty, lambda { |_query|
+      where("words.syllables": "")
     }
 
     scope :filter_cologne_phonetics, lambda { |query|

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -46,7 +46,7 @@ class SearchesController < PublicController
   end
 
   def permitted_filters
-    always_permitted = %i[filter_type filter_home]
+    always_permitted = %i[filter_type filter_home filter_syllables_empty]
     advanced_filters = %i[
       filter_wordstarts
       filter_wordends


### PR DESCRIPTION
Closes #501

This adds a filter to search for empty syllables. As soon as deployed, the following link shows all words without syllables:

https://wort.schule/seite/search?filterrific[filter_syllables_empty]=1

Note that the filter is not part of the form. As soon as you click any other filter (even a different word type), you lose the syllables filter. You would then need to manually add `filterrific[filter_syllables_empty]=1` to the URL.