### PR TITLE
Wording | Singular/plural

### DIFF
--- a/app/controllers/word_view_settings_controller.rb
+++ b/app/controllers/word_view_settings_controller.rb
@@ -63,7 +63,8 @@ class WordViewSettingsController < ApplicationController
       :show_fresch_symbols,
       :show_gender_symbols,
       :word_type_wording,
-      :genus_wording
+      :genus_wording,
+      :numerus_wording
     )
   end
 end

--- a/app/helpers/word_view_settings_helper.rb
+++ b/app/helpers/word_view_settings_helper.rb
@@ -37,4 +37,8 @@ module WordViewSettingsHelper
       klass.model_name.name
     )
   end
+
+  def current_numerus_wording
+    current_word_view_setting.numerus_wording
+  end
 end

--- a/app/models/word_view_setting.rb
+++ b/app/models/word_view_setting.rb
@@ -15,6 +15,7 @@ class WordViewSetting < ApplicationRecord
   enumerize :visibility, in: %i[private public], default: :private
   enumerize :word_type_wording, in: WordTypes.keys, default: WordTypes.keys.first
   enumerize :genus_wording, in: Genus.keys, default: Genus.keys.first
+  enumerize :numerus_wording, in: Numerus.keys, default: Numerus.keys.first
 
   validates :name, presence: true
   validate :public_visibility_only_for_admins

--- a/app/services/numerus.rb
+++ b/app/services/numerus.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class Numerus
+  NAMES = [
+    {
+      key: "default",
+      singular: "Singular",
+      plural: "Plural",
+      singularetantum: "Singularwort",
+      pluraletantum: "Pluralwort"
+    },
+    {
+      key: "german",
+      singular: "Einzahl",
+      plural: "Mehrzahl",
+      singularetantum: "Einzahlwort",
+      pluraletantum: "Mehrzahlwort"
+    }
+  ].freeze
+
+  def self.singular(key)
+    NAMES.find { |names| names[:key] == (key || "default") }[:singular]
+  end
+
+  def self.plural(key)
+    NAMES.find { |names| names[:key] == (key || "default") }[:plural]
+  end
+
+  def self.singularetantum(key)
+    NAMES.find { |names| names[:key] == (key || "default") }[:singularetantum]
+  end
+
+  def self.pluraletantum(key)
+    NAMES.find { |names| names[:key] == (key || "default") }[:pluraletantum]
+  end
+
+  def self.keys
+    as_collection.map(&:second)
+  end
+
+  def self.as_collection
+    NAMES
+      .map do |config|
+        key = config[:key]
+        label = label_all(config[:key])
+
+        [label, key]
+      end
+  end
+
+  def self.label_all(key)
+    config = NAMES.find { |names| names[:key] == key }
+
+    "#{config[:singular]}/#{config[:plural]} — #{config[:singularetantum]}/#{config[:pluraletantum]}"
+  end
+end

--- a/app/services/theme_variables.rb
+++ b/app/services/theme_variables.rb
@@ -92,12 +92,14 @@ class ThemeVariables
       header: view_context&.controller&.render_to_string(partial: "nouns/header", locals: {noun: word, current_user: view_context&.current_user}),
       labels: {
         **shared_labels,
+        singularetantum: Numerus.singularetantum(view_context&.current_numerus_wording),
+        pluraletantum: Numerus.pluraletantum(view_context&.current_numerus_wording),
         case_1: I18n.t("theme.labels.case_1"),
         case_2: I18n.t("theme.labels.case_2"),
         case_3: I18n.t("theme.labels.case_3"),
         case_4: I18n.t("theme.labels.case_4"),
-        singular: I18n.t("theme.labels.singular"),
-        plural: I18n.t("theme.labels.plural")
+        singular: Numerus.singular(view_context&.current_numerus_wording),
+        plural: Numerus.plural(view_context&.current_numerus_wording)
       }
     }
   end
@@ -129,8 +131,8 @@ class ThemeVariables
       header: view_context&.controller&.render_to_string(partial: "verbs/header", locals: {verb: word, current_user: view_context&.current_user}),
       labels: {
         **shared_labels,
-        singular: I18n.t("theme.labels.singular"),
-        plural: I18n.t("theme.labels.plural"),
+        singular: Numerus.singular(view_context&.current_numerus_wording),
+        plural: Numerus.plural(view_context&.current_numerus_wording),
         singular_1_pronoun: Verb.human_attribute_name(:singular_1_pronoun),
         singular_2_pronoun: Verb.human_attribute_name(:singular_2_pronoun),
         singular_3_pronoun: Verb.human_attribute_name(:singular_3_pronoun),

--- a/app/views/nouns/_header.html.haml
+++ b/app/views/nouns/_header.html.haml
@@ -6,7 +6,7 @@
       = noun.name
 
   - component.with_property do
-    = render LabeledValueComponent.new(label: Noun.human_attribute_name(:plural), value: noun.full_plural)
+    = render LabeledValueComponent.new(label: Numerus.plural(current_numerus_wording), value: noun.full_plural)
   - component.with_property do
     = render LabeledValueComponent.new(label: Noun.human_attribute_name(:genus_id), value: 'test') do
       .flex.gap-2.items-center

--- a/app/views/themes/default_noun.liquid
+++ b/app/views/themes/default_noun.liquid
@@ -6,8 +6,8 @@
       {% if genus_neuter != blank %}<div>Form (Neutrum)</div><div>{{ genus_neuter }}</div>{% endif %}
       {% if genus_masculine != blank %}<div>Form (Maskulinum)</div><div>{{ genus_masculine }}</div>{% endif %}
       {% if genus_feminine != blank %}<div>Form (Femininum)</div><div>{{ genus_feminine }}</div>{% endif %}
-      <div>Singularwort</div><div>{{ singularetantum }}</div>
-      <div>Pluralwort</div><div>{{ pluraletantum }}</div>
+      <div>{{ labels.singularetantum }}</div><div>{{ singularetantum }}</div>
+      <div>{{ labels.pluraletantum }}</div><div>{{ pluraletantum }}</div>
     {% endbox_grid %}
   {% endbox %}
 
@@ -26,13 +26,13 @@
           <div class="flex gap-1 font-bold">
             {{ case_1_singular_article }} {{ case_1_singular }}
           </div>
-          <div class="text-sm">Singular</div>
+          <div class="text-sm">{{ labels.singular }}</div>
         </div>
         <div>
           <div class="flex gap-1 font-bold">
             {{ case_1_plural_article }} {{ case_1_plural }}
           </div>
-          <div class="text-sm">Plural</div>
+          <div class="text-sm">{{ labels.plural }}</div>
         </div>
 
         <div class="col-span-2 lg:col-span-1">
@@ -45,13 +45,13 @@
           <div class="flex gap-1 font-bold">
             {{ case_2_singular_article }} {{ case_2_singular }}
           </div>
-          <div class="text-sm">Singular</div>
+          <div class="text-sm">{{ labels.singular }}</div>
         </div>
         <div>
           <div class="flex gap-1 font-bold">
             {{ case_2_plural_article }} {{ case_2_plural }}
           </div>
-          <div class="text-sm">Plural</div>
+          <div class="text-sm">{{ labels.plural }}</div>
         </div>
 
         <div class="col-span-2 lg:col-span-1">
@@ -64,13 +64,13 @@
           <div class="flex gap-1 font-bold">
             {{ case_3_singular_article }} {{ case_3_singular }}
           </div>
-          <div class="text-sm">Singular</div>
+          <div class="text-sm">{{ labels.singular }}</div>
         </div>
         <div>
           <div class="flex gap-1 font-bold">
             {{ case_3_plural_article }} {{ case_3_plural }}
           </div>
-          <div class="text-sm">Plural</div>
+          <div class="text-sm">{{ labels.plural }}</div>
         </div>
 
         <div class="col-span-2 lg:col-span-1">
@@ -83,13 +83,13 @@
           <div class="flex gap-1 font-bold">
             {{ case_4_singular_article }} {{ case_4_singular }}
           </div>
-          <div class="text-sm">Singular</div>
+          <div class="text-sm">{{ labels.singular }}</div>
         </div>
         <div>
           <div class="flex gap-1 font-bold">
             {{ case_4_plural_article }} {{ case_4_plural }}
           </div>
-          <div class="text-sm">Plural</div>
+          <div class="text-sm">{{ labels.plural }}</div>
         </div>
       {% endbox_grid %}
     {% endbox %}

--- a/app/views/themes/default_verb.liquid
+++ b/app/views/themes/default_verb.liquid
@@ -17,11 +17,11 @@
         <div>Imperativ</div>
         <div>
           {{ imperative_singular }}
-          <div class="text-sm">Singular</div>
+          <div class="text-sm">{{ labels.singular }}</div>
         </div>
         <div>
           {{ imperative_plural }}
-          <div class="text-sm">Plural</div>
+          <div class="text-sm">{{ labels.plural }}</div>
         </div>
       {% endif %}
       {% if participle != blank || past_participle != blank %}
@@ -52,14 +52,14 @@
       {% box_grid 4 %}
         <div>
           <div>Präsens</div>
-          <div class="text-sm">Singular</div>
+          <div class="text-sm">{{ labels.singular }}</div>
         </div>
         <div>ich {{ present_singular_1 }}</div>
         <div>du {{ present_singular_2 }}</div>
         <div>er/sie/es {{ present_singular_3 }}</div>
         <div>
           <div>Präsens</div>
-          <div class="text-sm">Plural</div>
+          <div class="text-sm">{{ labels.plural }}</div>
         </div>
         <div>wir {{ present_plural_1 }}</div>
         <div>ihr {{ present_plural_2 }}</div>
@@ -67,14 +67,14 @@
 
         <div>
           <div>Präteritum</div>
-          <div class="text-sm">Singular</div>
+          <div class="text-sm">{{ labels.singular }}</div>
         </div>
         <div>ich {{ past_singular_1 }}</div>
         <div>du {{ past_singular_2 }}</div>
         <div>er/sie/es {{ past_singular_3 }}</div>
         <div>
           <div>Präteritum</div>
-          <div class="text-sm">Plural</div>
+          <div class="text-sm">{{ labels.plural }}</div>
         </div>
         <div>wir {{ past_plural_1 }}</div>
         <div>ihr {{ past_plural_2 }}</div>

--- a/app/views/word_view_settings/_form.html.haml
+++ b/app/views/word_view_settings/_form.html.haml
@@ -16,6 +16,7 @@
       = f.input :show_gender_symbols
       = f.input :word_type_wording, collection: WordTypes.as_collection, include_blank: false
       = f.input :genus_wording, collection: Genus.as_collection, include_blank: false
+      = f.input :numerus_wording, collection: Numerus.as_collection, include_blank: false
       - if current_user.role.Admin?
         = f.input :visibility, include_blank: false
 

--- a/app/views/word_view_settings/show.html.haml
+++ b/app/views/word_view_settings/show.html.haml
@@ -54,6 +54,9 @@
       = render(list.add(WordViewSetting.human_attribute_name(:genus_wording), "", hide_if_blank: false)) do
         = Genus.label_all(@word_view_setting.genus_wording)
 
+      = render(list.add(WordViewSetting.human_attribute_name(:numerus_wording), "", hide_if_blank: false)) do
+        = Numerus.label_all(@word_view_setting.numerus_wording)
+
       = render(list.add(WordViewSetting.human_attribute_name(:visibility))) do
         = @word_view_setting.visibility_text
 

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -244,5 +244,6 @@ de:
         show_gender_symbols: Symbole für Wortgeschlecht anzeigen
         word_type_wording: Bezeichnung Worttypen
         genus_wording: Bezeichnung Wortgeschlechter
+        numerus_wording: Bezeichnung Numerus
         no_font: Standardschrift
         visibility: Sichtbarkeit

--- a/config/locales/themes.de.yml
+++ b/config/locales/themes.de.yml
@@ -11,8 +11,6 @@ de:
       case_2: '2. Fall (wessen)'
       case_3: '3. Fall (wem)'
       case_4: '4. Fall (wen/was)'
-      singular: Einzahl
-      plural: Mehrzahl
       present: Präsens
       past: Präteritum
       absolute: Absolutes Adjektiv (nicht steigerbar)

--- a/db/migrate/20240630150641_add_numerus_wording_to_word_view_settings.rb
+++ b/db/migrate/20240630150641_add_numerus_wording_to_word_view_settings.rb
@@ -1,0 +1,5 @@
+class AddNumerusWordingToWordViewSettings < ActiveRecord::Migration[7.1]
+  def change
+    add_column :word_view_settings, :numerus_wording, :string, null: false, default: "default"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_16_152222) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_30_150641) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pgcrypto"
@@ -398,6 +398,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_16_152222) do
     t.boolean "show_gender_symbols", default: true, null: false
     t.string "word_type_wording", default: "default", null: false
     t.string "genus_wording", default: "default", null: false
+    t.string "numerus_wording", default: "default", null: false
     t.index ["owner_id"], name: "index_word_view_settings_on_owner_id"
     t.index ["theme_adjective_id"], name: "index_word_view_settings_on_theme_adjective_id"
     t.index ["theme_function_word_id"], name: "index_word_view_settings_on_theme_function_word_id"


### PR DESCRIPTION
Closes #111.

Adds an option for the wording of singular/plural.

<img width="521" alt="image" src="https://github.com/wort-schule/wort.schule/assets/1394828/e713e81b-0a25-4742-8901-9232db1638d0">

Depending on what is selected in the view settings, we then show either `Singular/Plural` or `Einzahl/Mehrzahl`.