### PR TITLE
Add hint about link to word view setting

### DIFF
--- a/app/views/word_view_settings/show.html.haml
+++ b/app/views/word_view_settings/show.html.haml
@@ -60,6 +60,20 @@
       = render(list.add(WordViewSetting.human_attribute_name(:visibility))) do
         = @word_view_setting.visibility_text
 
+- if @word_view_setting.visibility.public?
+  = two_column_card t('.session_set_link.title'), "", first: false do
+    = box padding: true do
+      .flex.flex-col.gap-2
+        = t('.session_set_link.explanation_html')
+
+      - share_url = root_url(word_view_setting_id: @word_view_setting.id)
+      .my-4.flex.flex-col.gap-1(data-controller="clipboard"){ 'data-clipboard-success-content': t('.session_set_link.copied') }
+        %input.pre(type="text" name="share_url" readonly data-clipboard-target="source"){ value: share_url }
+        .flex.flex-wrap.gap-4.justify-between
+          = link_to t('.session_set_link.open_link'), share_url, target: '_blank'
+          %button.self-end(type="button" data-action="clipboard#copy" data-clipboard-target="button")
+            = t '.session_set_link.copy'
+
 = two_column_card LearningGroup.model_name.human(count: 2), "" do
   = box padding: false, class: 'striped' do
     - if @word_view_setting.learning_groups.empty?

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -290,6 +290,15 @@ de:
       new: Neue Wort-Ansichtseinstellung
     show:
       not_used_yet: Diese Ansichtseinstellung wird in keiner Lerngruppe verwendet.
+      session_set_link:
+        title: Teilbarer Link
+        explanation_html: |
+          <p>Der folgende Link kann weitergegeben werden um diese Ansichtseinstellung zu verwenden.</p>
+          <p>Wird der Link geöffnet, wird für diese Browser-Session diese Ansichtseinstellung verwendet. Ist die Benutzer*in angemeldet, wird im Profil diese Ansichtseinstellung übernommen und permanent gespeichert. Angemeldete Benutzer*innen können im Profil jederzeit die Ansichtseinstellung ändern.<p>
+          <p>Dieser Link kann als Lesezeichen gespeichert werden um sicherzustellen, dass bei Aufruf des Lesezeichens die gewünschte Ansichtseinstellung verwendet wird.</p>
+        open_link: Link öffnen
+        copy: In Zwischenablage kopieren
+        copied: Kopiert!
     new:
       title: Wort-Ansichtseinstellung erstellen
     edit:


### PR DESCRIPTION
Closes #508

Adds the link and explanation on how to use the word view setting link.

<img width="797" alt="image" src="https://github.com/wort-schule/wort.schule/assets/1394828/357cb626-4167-4f14-8c59-7dfd6d4793ba">
