### PR TITLE
Keywords | Behavior

### DIFF
--- a/app/controllers/hierarchies_controller.rb
+++ b/app/controllers/hierarchies_controller.rb
@@ -5,6 +5,8 @@ class HierarchiesController < PublicController
 
   def index
     @hierarchies = @hierarchies.order(:name).page(params[:page])
+    @show_children = ActiveRecord::Type::Boolean.new.cast(params[:show_children])
+    @hierarchies = @hierarchies.where(parent: nil) unless @show_children
   end
 
   def show

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -19,7 +19,7 @@ class KeywordsController < PublicController
   def show
     @keyword = Word.friendly.find(params[:id])
     @all_words = Word.where(id: Keyword.where(keyword_id: @keyword.id).pluck(:word_id))
-    @related_keywords = Word.where(id: Keyword.where(keyword_id: @all_words.pluck(:id)).pluck(:keyword_id)).page(params[:page])
+    @related_keywords = Word.where(id: Keyword.where(word_id: @all_words.pluck(:id)).pluck(:keyword_id)).page(params[:page])
     @words = @all_words.page(params[:page])
   end
 end

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -3,7 +3,7 @@
 module ComponentsHelper
   def title_with_actions(title, &block)
     content_tag :div, class: "flex flex-col md:flex-row md:justify-between items-start md:items-center title px-4 md:px-0 gap-4" do
-      concat content_tag :h1, title
+      concat content_tag :h1, title, class: "mt-0"
       concat content_tag :div, class: "flex flex-wrap justify-end gap-2", &block if block
     end
   end

--- a/app/views/hierarchies/index.html.haml
+++ b/app/views/hierarchies/index.html.haml
@@ -1,4 +1,8 @@
-= title_with_actions Hierarchy.model_name.human(count: 2)
+= title_with_actions Hierarchy.model_name.human(count: 2) do
+  - if @show_children
+    = link_to t('.hide_children'), url_for(show_children: false), class: 'button'
+  - else
+    = link_to t('.show_children'), url_for(show_children: true), class: 'button'
 
 = index_grid do
   = render @hierarchies

--- a/app/views/keywords/index.html.haml
+++ b/app/views/keywords/index.html.haml
@@ -2,7 +2,7 @@
   %h1= t '.title'
   .grid.my-6.gap-4.grid-cols-1.lg:grid-cols-2.xl:grid-cols-3
     - @keywords.each do |keyword|
-      = render WordPanelComponent.new(word: keyword, url: keyword_path(keyword.slug)) do |component|
+      = render WordPanelComponent.new(word: keyword, url: keyword_path(keyword_ids: keyword.id)) do |component|
         - component.with_description do
           = t('keywords.index.words_count', count: Keyword.words_count(keyword.id))
 

--- a/app/views/keywords/show.html.haml
+++ b/app/views/keywords/show.html.haml
@@ -1,13 +1,18 @@
 .mb-4= link_to t('.back'), keywords_path
 
-= render WordPanelComponent.new(word: @keyword, menu: true)
+.grid.my-6.gap-4.grid-cols-1.lg:grid-cols-2.xl:grid-cols-3
+  - @keywords.each do |keyword|
+    = render WordPanelComponent.new(word: keyword, menu: true) do |component|
+      - if @keyword_ids.count > 1
+        - component.with_description do
+          = link_to t('.remove'), keyword_path(keyword_ids: (@keyword_ids - [keyword.id.to_s]).join(','))
 
 = turbo_frame_tag :related_keywords do
   - if @related_keywords.present?
     %h1= t '.related_keywords.title'
     .grid.my-6.gap-4.grid-cols-1.lg:grid-cols-2.xl:grid-cols-3
       - @related_keywords.each do |word|
-        = render WordPanelComponent.new(word:, url: keyword_path(word.slug)) do |component|
+        = render WordPanelComponent.new(word:, url: keyword_path(keyword_ids: params[:keyword_ids] + ",#{word.id}")) do |component|
           - component.with_description do
             = t('keywords.index.words_count', count: Keyword.words_count(word.id))
 

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -138,6 +138,8 @@ de:
   hierarchies:
     index:
       new: Neue Kategorie
+      show_children: Unterkategorien anzeigen
+      hide_children: Unterkategorien verstecken
     show:
       back: '← Zurück zu allen Kategorien'
       children:

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -353,6 +353,7 @@ de:
         other: '%{count} Wörter'
     show:
       back: '← Zurück zu allen Stichwörtern'
+      remove: Entfernen
       words:
         title: Wörter
       related_keywords:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,7 +93,8 @@ Rails.application.routes.draw do
     post :list_add_word, to: "lists#add_word"
     resources :flashcards, only: :index
     resources :word_view_settings
-    resources :keywords, only: %i[index show]
+    resources :keywords, only: :index
+    resource :keyword, only: :show
 
     # User's own routes
     resource :profile, only: %i[show edit update] do


### PR DESCRIPTION
Closes #492.

## Changes

- Hierarchies now have a button to show/hide children

![screengrab-20240701-2247](https://github.com/wort-schule/wort.schule/assets/1394828/362c84ad-2531-4113-a3ac-ccc44ca41475)

- Change behavior of the keywords page: you can now select multiple keywords and it only shows words which have all those keywords.
- Related keywords are now shown correctly

![screengrab-20240701-2248](https://github.com/wort-schule/wort.schule/assets/1394828/d6f8a2aa-95c0-4da0-b7f1-890331811c2c)
