### PR TITLE
Fix access to word view settings for guests

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,6 +14,7 @@ class Ability
     can :read, Source, visible: true
     can :read, Keyword
     can :read, Hierarchy
+    can :read, WordViewSetting, visibility: :public
 
     if user.present?
       can %i[show edit update destroy], User, %i[first_name last_name avatar email password word_view_setting_id], id: user.id


### PR DESCRIPTION
Closes #516

This fixes links as https://wort.schule/?word_view_setting_id=1 for users who are not logged in.

We authorize the view settings, which is in general a good idea. I just forgot to allow access to public view settings to everyone.