### PR TITLE
Change word header to contain word only once

### DIFF
--- a/app/components/syllables_component.html.haml
+++ b/app/components/syllables_component.html.haml
@@ -1,9 +1,12 @@
-.mt-8.syllables-font
+.mt-4.syllables-font
   - if word_view_setting.show_house
     = "`9 "
 
-  - if word_view_setting.show_syllable_arcs
+  - if word_prefix.present?
+    = word_prefix
+
+  - if word_view_setting.show_syllable_arcs && syllables.compact_blank.present?
     - syllables_with_arcs.each do |syllable|
       %span{ class: word_view_setting.color_syllables ? cycle('syllable-color1', 'syllable-color2') : nil }>= syllable
   - else
-    = syllables.join
+    = syllables.join.presence || word

--- a/app/components/syllables_component.rb
+++ b/app/components/syllables_component.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 class SyllablesComponent < ViewComponent::Base
-  attr_reader :syllables, :word_view_setting
+  attr_reader :syllables, :word_prefix, :word, :word_view_setting
 
-  def initialize(text:, word_view_setting:)
+  def initialize(text:, word_prefix:, word:, word_view_setting:)
     @syllables = parse_syllables(text)
+    @word_prefix = word_prefix
+    @word = word
     @word_view_setting = word_view_setting
   end
 
@@ -14,10 +16,6 @@ class SyllablesComponent < ViewComponent::Base
 
       "#{arc}#{syllable}"
     end
-  end
-
-  def render?
-    syllables.compact_blank.present?
   end
 
   private

--- a/app/components/word_header_component.html.haml
+++ b/app/components/word_header_component.html.haml
@@ -1,7 +1,6 @@
 .word-header.md:bg-white.md:shadow.md:rounded-3xl.md:col-span-2.gap-4.lg:gap-12
   .m-6.word-font(style="grid-area: name")
-    %div= title
-    .mt-4.text-lg.md:text-2xl= render SyllablesComponent.new(text: word.syllables, word_view_setting: helpers.current_word_view_setting)
+    %h1= render SyllablesComponent.new(text: word.syllables, word_prefix: title, word: word.name, word_view_setting: helpers.current_word_view_setting)
 
   .properties(style="grid-area: properties")
     .flex.flex-col.gap-4.justify-center

--- a/app/views/adjectives/_header.html.haml
+++ b/app/views/adjectives/_header.html.haml
@@ -1,7 +1,4 @@
 = render WordHeaderComponent.new(word: adjective, word_font: current_font) do |component|
-  - component.with_title do
-    %h1= adjective.name
-
   - component.with_property do
     = render LabeledValueComponent.new(label: Adjective.human_attribute_name(:comparative), value: adjective.comparative)
   - component.with_property do

--- a/app/views/function_words/_header.html.haml
+++ b/app/views/function_words/_header.html.haml
@@ -1,3 +1,1 @@
-= render WordHeaderComponent.new(word: function_word, word_font: current_font) do |component|
-  - component.with_title do
-    %h1= function_word.name
+= render WordHeaderComponent.new(word: function_word, word_font: current_font)

--- a/app/views/nouns/_header.html.haml
+++ b/app/views/nouns/_header.html.haml
@@ -1,9 +1,6 @@
 = render WordHeaderComponent.new(word: noun, word_font: current_font) do |component|
   - component.with_title do
-    %h1.flex.items-baseline.gap-1.m-0
-      - if noun.genus.present?
-        .text-2xl.md:text-3xl.font-normal= noun.article_definite(case_number: 1, singular: true)
-      = noun.name
+    = noun.article_definite(case_number: 1, singular: true)
 
   - component.with_property do
     = render LabeledValueComponent.new(label: Numerus.plural(current_numerus_wording), value: noun.full_plural)


### PR DESCRIPTION
Closes #521

Removes the duplicate word names we had in the header (once normal and once syllables):

![image](https://github.com/wort-schule/wort.schule/assets/1394828/83ff58e0-2b40-4c64-91d9-4c3421538a2b)

If there are no syllables:

![image](https://github.com/wort-schule/wort.schule/assets/1394828/ac8e2cb5-d905-4d14-a737-404b21fe0818)
