### PR TITLE
Fix duplicate words in header of verbs

### DIFF
--- a/app/views/verbs/_header.html.haml
+++ b/app/views/verbs/_header.html.haml
@@ -1,3 +1,1 @@
-= render WordHeaderComponent.new(word: verb, word_font: current_font) do |component|
-  - component.with_title do
-    %h1= verb.name
+= render WordHeaderComponent.new(word: verb, word_font: current_font)


### PR DESCRIPTION
Closes #521

![image](https://github.com/wort-schule/wort.schule/assets/1394828/5a5621ca-4207-4730-9699-e4991a1f5e72)
