### PR TITLE
LLM | Proof of concept

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "redis", "~> 5.3" # Use Redis for Action Cable
 gem "route_downcaser"
 gem "ruby-vips"
 gem "sanitize"
+gem "scenic"
 gem "simple_form"
 gem "stimulus-rails"
 gem "tailwindcss-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "devise"
 gem "devise-i18n"
 gem "draper"
 gem "enumerize"
+gem "faraday"
 gem "filterrific", github: "metikular/filterrific", branch: "fix/nested-array"
 gem "friendly_id"
 gem "good_job", "< 5"
@@ -27,6 +28,7 @@ gem "heroicon"
 gem "humanize_boolean"
 gem "image_processing"
 gem "importmap-rails"
+gem "instructor-rb", github: "instructor-ai/instructor-rb", require: "instructor"
 gem "jbuilder"
 gem "kaminari"
 gem "liquid"
@@ -64,6 +66,7 @@ group :test do
   gem "capybara-screenshot"
   gem "cuprite"
   gem "simplecov", require: false
+  gem "webmock"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/instructor-ai/instructor-rb.git
+  revision: e96ab3b4e9c8c1d08c8f784c0ac091f33a12a916
+  specs:
+    instructor-rb (0.1.3)
+      activesupport (~> 7.0)
+      anthropic (~> 0.2)
+      easy_talk (~> 0.2)
+      ruby-openai (~> 7)
+
+GIT
   remote: https://github.com/metikular/filterrific.git
   revision: f4e3cf81296c4c6317374cc684e7aafbd4ea5b77
   branch: fix/nested-array
@@ -100,6 +110,10 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    anthropic (0.3.2)
+      event_stream_parser (>= 0.3.0, < 2.0.0)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
@@ -137,6 +151,9 @@ GEM
       unaccent (~> 0.3)
     country_select (9.0.0)
       countries (> 5.0, < 7.0)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     cuprite (0.15.1)
       capybara (~> 3.0)
@@ -165,11 +182,17 @@ GEM
       request_store (>= 1.0)
       ruby2_keywords
     drb (2.2.1)
+    easy_talk (0.2.2)
+      activemodel (~> 7.0)
+      activesupport (~> 7.0)
+      json_schemer
+      sorbet-runtime (~> 0.5)
     enumerize (2.8.1)
       activesupport (>= 3.2)
     erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
+    event_stream_parser (1.0.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
@@ -177,9 +200,12 @@ GEM
       railties (>= 5.0.0)
     faker (3.4.2)
       i18n (>= 1.8.11, < 2)
-    faraday (2.11.0)
+    faraday (2.12.0)
       faraday-net_http (>= 2.0, < 3.4)
+      json
       logger
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
     faraday-net_http (3.3.0)
       net-http
     faraday-retry (2.2.1)
@@ -271,6 +297,8 @@ GEM
       activesupport (>= 5.1)
       haml (>= 4.0.6)
       railties (>= 5.1)
+    hana (1.3.7)
+    hashdiff (1.1.1)
     heroicon (1.0.0)
       rails (>= 5.2)
     humanize_boolean (0.0.2)
@@ -292,6 +320,11 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.7.2)
+    json_schemer (2.3.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     jwt (2.8.2)
       base64
     kaminari (1.2.2)
@@ -314,7 +347,7 @@ GEM
       launchy (>= 2.2, < 4)
     lint_roller (1.1.0)
     liquid (5.5.1)
-    logger (1.6.0)
+    logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -336,6 +369,7 @@ GEM
     minitest (5.25.1)
     msgpack (1.7.2)
     multi_json (1.15.0)
+    multipart-post (2.4.1)
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
@@ -477,6 +511,10 @@ GEM
     rubocop-performance (1.21.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-openai (7.3.1)
+      event_stream_parser (>= 0.3.0, < 2.0.0)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)
@@ -499,6 +537,8 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    simpleidn (0.2.3)
+    sorbet-runtime (0.5.11609)
     standard (1.36.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -537,7 +577,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unaccent (0.4.0)
     unicode-display_width (2.5.0)
-    uri (0.13.0)
+    uri (0.13.1)
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
@@ -552,6 +592,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.24.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -588,6 +632,7 @@ DEPENDENCIES
   factory_bot
   factory_bot_rails
   faker
+  faraday
   filterrific!
   foreman
   friendly_id
@@ -599,6 +644,7 @@ DEPENDENCIES
   humanize_boolean
   image_processing
   importmap-rails
+  instructor-rb!
   jbuilder
   kaminari
   letter_opener
@@ -629,6 +675,7 @@ DEPENDENCIES
   validate_url
   view_component
   web-console
+  webmock
 
 RUBY VERSION
    ruby 3.3.1p55

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -523,6 +523,9 @@ GEM
     sanitize (6.1.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    scenic (1.8.0)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
     signet (0.19.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -664,6 +667,7 @@ DEPENDENCIES
   rspec-rails
   ruby-vips
   sanitize
+  scenic
   simple_form
   simplecov
   standardrb

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class ReviewsController < ApplicationController
+  authorize_resource :review, class: false
+
+  before_action :set_reviewable, only: %i[show new create update]
+
+  rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_next_review
+
+  def index
+    redirect_to_next_review
+  end
+
+  def show
+  end
+
+  def new
+  end
+
+  def create
+    if @reviewable.value == params[:word_attribute_edit][:value]
+      @reviewable.errors.add(:value, t(".must_be_different"))
+
+      return render :new, status: :unprocessable_entity
+    end
+
+    @reviewable.transaction do
+      successor = WordAttributeEdit
+        .create!(
+          word: @reviewable.word,
+          attribute_name: @reviewable.attribute_name,
+          value: params[:word_attribute_edit][:value],
+          state: :waiting_for_review
+        )
+
+      @reviewable.update!(
+        state: :edited,
+        successor:
+      )
+
+      Review.create!(
+        state: :edited,
+        reviewable: @reviewable,
+        reviewer: current_user
+      )
+    end
+
+    redirect_to_next_review
+  end
+
+  def update
+    @reviewable.store_review(
+      reviewer: current_user,
+      state: params[:state]
+    )
+
+    redirect_to_next_review
+  end
+
+  private
+
+  def set_reviewable
+    @reviewable = WordAttributeEdit.find(params[:id])
+  end
+
+  def redirect_to_next_review
+    @next_review = WordAttributeEdit.reviewable(current_user.id).first
+
+    if @next_review
+      redirect_to review_path(@next_review)
+    else
+      redirect_to reviews_path unless params[:action] == "index"
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -85,6 +85,8 @@ class Ability
         can :manage, Theme
         can :manage, List
 
+        can :manage, :review
+
         # User management
         can :manage, User
         can :manage, LearningGroup

--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Reviewable
+  extend ActiveSupport::Concern
+
+  REVIEWS_REQUIRED = 2
+
+  included do
+    attr_accessor :action
+
+    scope :reviewable, ->(reviewer_id) {
+      where(successor_id: nil)
+        .where(state: :waiting_for_review)
+        .where(
+          id: select(:id)
+        .where("NOT EXISTS (SELECT 1 FROM reviewers WHERE reviewers.word_attribute_edit_id = word_attribute_edits.id AND reviewers.reviewer_id = ?)", reviewer_id)
+        )
+        .order(:created_at)
+    }
+
+    belongs_to :successor, optional: true, polymorphic: true
+
+    has_many :reviewers, dependent: nil
+
+    def store_review(reviewer:, state:)
+      reviews.create!(
+        reviewer:,
+        state:
+      )
+
+      try_to_finish_review
+    end
+
+    def confirmed_review_count
+      reviews.where(state: :confirmed).count
+    end
+
+    def try_to_finish_review
+      return if confirmed_review_count < REVIEWS_REQUIRED
+
+      transaction do
+        update!(state: :confirmed)
+
+        word.update!(attribute_name => value)
+      end
+    end
+  end
+end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Review < ApplicationRecord
+  extend Enumerize
+
+  belongs_to :reviewable, polymorphic: true
+  belongs_to :reviewer, class_name: "User"
+
+  enumerize :state, in: %i[skipped edited confirmed]
+end

--- a/app/models/reviewer.rb
+++ b/app/models/reviewer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Reviewer < ApplicationRecord
+  belongs_to :word_attribute_edit
+  belongs_to :reviewer, class_name: "User"
+
+  def readonly?
+    true
+  end
+end

--- a/app/models/word_attribute_edit.rb
+++ b/app/models/word_attribute_edit.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class WordAttributeEdit < ApplicationRecord
+  extend Enumerize
+
+  belongs_to :word, polymorphic: true
+
+  enumerize :state, in: %i[waiting_for_review], default: :waiting_for_review
+end

--- a/app/models/word_attribute_edit.rb
+++ b/app/models/word_attribute_edit.rb
@@ -2,8 +2,23 @@
 
 class WordAttributeEdit < ApplicationRecord
   extend Enumerize
+  include Reviewable
 
   belongs_to :word, polymorphic: true
 
-  enumerize :state, in: %i[waiting_for_review], default: :waiting_for_review
+  has_many :reviews, dependent: :destroy, inverse_of: :reviewable
+
+  enumerize :state, in: %i[waiting_for_review edited confirmed], default: :waiting_for_review
+
+  def attribute_label
+    word.class.human_attribute_name(attribute_name)
+  end
+
+  def current_value
+    word.send(attribute_name)
+  end
+
+  def proposed_value
+    value
+  end
 end

--- a/app/models/word_llm_enrichment.rb
+++ b/app/models/word_llm_enrichment.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class WordLlmEnrichment < ApplicationRecord
+  extend Enumerize
+
+  belongs_to :word, polymorphic: true
+
+  enumerize :state, in: %i[invoked failed completed], default: :invoked
+end

--- a/app/services/llm/enrich.rb
+++ b/app/services/llm/enrich.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Llm
+  class Enrich
+    attr_reader :word, :word_llm_enrichment
+
+    def initialize(word:)
+      @word = word
+    end
+
+    def call
+      return if pending_llm_response?
+
+      initialize_word_llm_enrichment
+      response = llm_response
+      create_enriched_attributes(response)
+      word_llm_enrichment.update!(state: :completed)
+    rescue => e
+      word_llm_enrichment&.update!(
+        state: :failed,
+        error: e.full_message
+      )
+
+      raise e if word_llm_enrichment.blank?
+    end
+
+    private
+
+    def pending_llm_response?
+      WordLlmEnrichment
+        .exists?(
+          word:,
+          state: %w[new invoked]
+        )
+    end
+
+    def initialize_word_llm_enrichment
+      @word_llm_enrichment ||= WordLlmEnrichment
+        .create!(
+          word:,
+          state: :invoked
+        )
+    end
+
+    def llm_response
+      @llm_respponse ||= Invoke.new(
+        response_model:,
+        prompt: <<~PROMPT
+          The following JSON includes all the information we have about the German word '#{word.name}'. Please correct and enrich that information. We use your response for students learning German. Please ensure that all your answers are in German and adhere to German grammar rules.
+
+          #{word.to_json}
+        PROMPT
+      ).call
+    end
+
+    def create_enriched_attributes(response)
+      ActiveRecord::Base.transaction do
+        response.properties.slice(*response_model.properties).each do |attribute_name, value|
+          next if word.send(attribute_name) == value
+
+          WordAttributeEdit
+            .find_or_create_by!(
+              word:,
+              attribute_name:,
+              value:,
+              state: :waiting_for_review
+            )
+        end
+      end
+    end
+
+    def response_model
+      case word.type
+      when "Noun" then Schema::Noun
+      else raise "Word type '#{word.type}' is not supported for LLM enrichment"
+      end
+    end
+  end
+end

--- a/app/services/llm/invoke.rb
+++ b/app/services/llm/invoke.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Llm
+  class Invoke
+    attr_reader :prompt, :response_model
+
+    def initialize(prompt:, response_model:)
+      @prompt = prompt
+      @response_model = response_model
+    end
+
+    def call
+      client.chat(
+        parameters: {
+          model: ENV["LLM_MODEL"].presence || "llama3.1",
+          messages: [{role: "user", content: prompt}]
+        },
+        response_model:
+      )
+    end
+
+    private
+
+    def client
+      @client ||= Instructor.from_openai(OpenAI::Client).new
+    end
+  end
+end

--- a/app/services/llm/schema/noun.rb
+++ b/app/services/llm/schema/noun.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Llm
+  module Schema
+    class Noun
+      include EasyTalk::Model
+
+      define_schema do
+        property :meaning, String, description: "A description in German which explains this word"
+        property :case_1_plural, String, description: "German plural form of this word"
+      end
+    end
+  end
+end

--- a/app/views/pages/navigation.html.haml
+++ b/app/views/pages/navigation.html.haml
@@ -7,7 +7,7 @@
   = navigation_link false, t('verbs.index.new'), new_verb_path if can?(:create, Verb)
   = navigation_link false, t('adjectives.index.new'), new_adjective_path if can?(:create, Adjective)
   = navigation_link false, Keyword.model_name.human(count: 2), keywords_path
-  = navigation_link false, Hierarchy.model_name.human(count: 2), hierarchies_path
+  = navigation_link false, t('navigation.reviews'), reviews_path if can?(:manage, :review)
 
   - if [FunctionWord, Topic, Prefix, Postfix, Phenomenon, Strategy, CompoundInterfix, CompoundPreconfix, CompoundPostconfix, CompoundPhonemreduction, CompoundVocalalternation].any? { |klass| can? :read, klass }
     .text-gray-300.hover:bg-primary-hover.hover:text-white.px-3.py-2.rounded-md.text-sm.font-medium

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -1,0 +1,3 @@
+%h1= t '.empty.title'
+
+%p.mt-4= t '.empty.explanation'

--- a/app/views/reviews/new.html.haml
+++ b/app/views/reviews/new.html.haml
@@ -1,0 +1,24 @@
+.p-4
+  = render @reviewable.word
+
+  .mt-6= t 'reviews.show.attribute'
+  .font-bold.text-lg= @reviewable.attribute_label
+
+  .grid.lg:grid-cols-2.mt-6.gap-6
+    = box do
+      %div= t 'reviews.show.current_value'
+      .font-bold.text-xl= @reviewable.current_value
+
+    = box do
+      %div= t 'reviews.show.proposed_value'
+      .font-bold.text-xl= @reviewable.proposed_value
+
+  .mt-4
+    = simple_form_for @reviewable, url: reviews_path(id: @reviewable), method: :post do |f|
+      = f.input :value, label: t('.new_proposal')
+
+  .flex.flex-wrap.md:gap-2.md:justify-end.mt-6
+    = form_tag review_path(@reviewable), method: :patch, class: 'grow md:grow-0' do
+      = hidden_field_tag :state, 'skipped'
+      = submit_tag t('reviews.show.actions.skip')
+    %button.button.primary.mt-4{ type: "submit", form: dom_id(@reviewable, :edit) }= t 'helpers.submit.update'

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -1,0 +1,23 @@
+.p-4
+  = render @reviewable.word
+
+  .mt-6= t '.attribute'
+  .font-bold.text-lg= @reviewable.attribute_label
+
+  .grid.lg:grid-cols-2.mt-6.gap-6
+    = box do
+      %div= t '.current_value'
+      .font-bold.text-xl= @reviewable.current_value
+
+    = box do
+      %div= t '.proposed_value'
+      .font-bold.text-xl= @reviewable.proposed_value
+
+  .flex.flex-wrap.md:gap-2.md:justify-end.mt-6
+    = form_tag review_path(@reviewable), method: :patch, class: 'grow md:grow-0' do
+      = hidden_field_tag :state, 'skipped'
+      = submit_tag t('.actions.skip')
+    = link_to t('.actions.edit'), new_review_path(id: @reviewable), class: 'button primary mt-4'
+    = form_tag review_path(@reviewable), method: :patch, class: 'grow md:grow-0' do
+      = hidden_field_tag :state, 'confirmed'
+      = submit_tag t('.actions.confirm')

--- a/config/initializers/open_ai.rb
+++ b/config/initializers/open_ai.rb
@@ -1,3 +1,7 @@
 Rails.application.config.to_prepare do
-  OpenAI.configuration.uri_base = ENV["OLLAMA_URL"]
+  OpenAI.configuration.uri_base = if Rails.env.test?
+    "https://ai.test"
+  else
+    ENV["OLLAMA_URL"]
+  end
 end

--- a/config/initializers/open_ai.rb
+++ b/config/initializers/open_ai.rb
@@ -1,0 +1,3 @@
+Rails.application.config.to_prepare do
+  OpenAI.configuration.uri_base = ENV["OLLAMA_URL"]
+end

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -121,6 +121,7 @@ de:
         genus_neuter: Form (Neutrum)
         genus_masculine: Form (Maskulinum)
         genus_feminine: Form (Femininum)
+        case_1_plural: '1. Fall / Nominativ Plural'
       source:
         name: Bezeichnung
         author: Autor*in(nen)

--- a/config/locales/navigation.de.yml
+++ b/config/locales/navigation.de.yml
@@ -9,3 +9,4 @@ de:
     learning: Lernen
     miscellaneous: Sonstiges
     site_title: wort.schule
+    reviews: Reviews

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -377,3 +377,19 @@ de:
         title: Wörter
       related_keywords:
         title: Verwandte Stichwörter
+
+  reviews:
+    index:
+      empty:
+        title: Keine Reviews vorhanden
+        explanation: Zur Zeit sind keine ausstehenden Reviews vorhanden. Bitte schauen Sie später nochmals vorbei!
+    show:
+      attribute: Vorschlag bezüglich
+      current_value: Aktuell
+      proposed_value: Vorschlag
+      actions:
+        skip: Überspringen
+        edit: Vorschlag anpassen
+        confirm: Vorschlag bestätigen
+    new:
+      new_proposal: Neuer Vorschlag

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,8 @@ Rails.application.routes.draw do
     resources :keywords, only: :index
     resource :keyword, only: :show
 
+    resources :reviews, only: %i[index show new create edit update]
+
     # User's own routes
     resource :profile, only: %i[show edit update] do
       resources :themes, only: %i[index update], module: :profiles

--- a/db/migrate/20241013162343_create_word_llm_enrichments.rb
+++ b/db/migrate/20241013162343_create_word_llm_enrichments.rb
@@ -1,0 +1,12 @@
+class CreateWordLlmEnrichments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :word_llm_enrichments do |t|
+      t.references :word, null: false, index: true, polymorphic: true
+      t.string :state, index: true, null: false, default: 'new'
+      t.text :error
+      t.datetime :completed_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241027151321_create_word_attribute_edits.rb
+++ b/db/migrate/20241027151321_create_word_attribute_edits.rb
@@ -1,0 +1,12 @@
+class CreateWordAttributeEdits < ActiveRecord::Migration[7.1]
+  def change
+    create_table :word_attribute_edits do |t|
+      t.references :word, null: false, polymorphic: true
+      t.string :attribute_name, null: false
+      t.string :value
+      t.string :state, null: false, default: 'waiting_for_review'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241102134932_create_reviews.rb
+++ b/db/migrate/20241102134932_create_reviews.rb
@@ -1,0 +1,11 @@
+class CreateReviews < ActiveRecord::Migration[7.1]
+  def change
+    create_table :reviews do |t|
+      t.references :reviewable, null: false, polymorphic: true
+      t.references :reviewer, null: false, foreign_key: {to_table: :users}
+      t.string :state, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241107191707_add_successor_to_word_attribute_edits.rb
+++ b/db/migrate/20241107191707_add_successor_to_word_attribute_edits.rb
@@ -1,0 +1,5 @@
+class AddSuccessorToWordAttributeEdits < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :word_attribute_edits, :successor, null: true, polymorphic: true
+  end
+end

--- a/db/migrate/20241108225727_create_reviewers.rb
+++ b/db/migrate/20241108225727_create_reviewers.rb
@@ -1,0 +1,5 @@
+class CreateReviewers < ActiveRecord::Migration[7.1]
+  def change
+    create_view :reviewers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_13_162343) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_27_151321) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pgcrypto"
@@ -396,6 +396,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_13_162343) do
     t.jsonb "object"
     t.jsonb "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+  end
+
+  create_table "word_attribute_edits", force: :cascade do |t|
+    t.string "word_type", null: false
+    t.bigint "word_id", null: false
+    t.string "attribute_name", null: false
+    t.string "value"
+    t.string "state", default: "waiting_for_review", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["word_type", "word_id"], name: "index_word_attribute_edits_on_word"
   end
 
   create_table "word_llm_enrichments", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_08_191832) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_13_162343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pgcrypto"
@@ -396,6 +396,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_191832) do
     t.jsonb "object"
     t.jsonb "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+  end
+
+  create_table "word_llm_enrichments", force: :cascade do |t|
+    t.string "word_type", null: false
+    t.bigint "word_id", null: false
+    t.string "state", default: "new", null: false
+    t.text "error"
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["state"], name: "index_word_llm_enrichments_on_state"
+    t.index ["word_type", "word_id"], name: "index_word_llm_enrichments_on_word"
   end
 
   create_table "word_view_settings", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_27_151321) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_08_225727) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pgcrypto"
@@ -284,6 +284,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_27_151321) do
     t.string "prefix_type", default: "Verb"
   end
 
+  create_table "reviews", force: :cascade do |t|
+    t.string "reviewable_type", null: false
+    t.bigint "reviewable_id", null: false
+    t.bigint "reviewer_id", null: false
+    t.string "state", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["reviewable_type", "reviewable_id"], name: "index_reviews_on_reviewable"
+    t.index ["reviewer_id"], name: "index_reviews_on_reviewer_id"
+  end
+
   create_table "rimes", id: false, force: :cascade do |t|
     t.integer "word_id"
     t.integer "rime_id"
@@ -406,6 +417,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_27_151321) do
     t.string "state", default: "waiting_for_review", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "successor_type"
+    t.bigint "successor_id"
+    t.index ["successor_type", "successor_id"], name: "index_word_attribute_edits_on_successor"
     t.index ["word_type", "word_id"], name: "index_word_attribute_edits_on_word"
   end
 
@@ -532,6 +546,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_27_151321) do
   add_foreign_key "learning_pleas", "learning_groups"
   add_foreign_key "learning_pleas", "lists"
   add_foreign_key "lists", "users"
+  add_foreign_key "reviews", "users", column: "reviewer_id"
   add_foreign_key "themes", "users"
   add_foreign_key "users", "word_view_settings"
   add_foreign_key "word_view_settings", "themes", column: "theme_adjective_id"
@@ -542,4 +557,28 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_27_151321) do
   add_foreign_key "words", "hierarchies"
   add_foreign_key "words", "postfixes"
   add_foreign_key "words", "prefixes"
+  create_view "reviewers", sql_definition: <<-SQL
+      WITH RECURSIVE successors(origin_id, edit_id) AS (
+           SELECT wae.id,
+              wae.id
+             FROM word_attribute_edits wae
+            WHERE (wae.successor_id IS NULL)
+          UNION
+           SELECT successors.origin_id,
+              wae.id
+             FROM (successors
+               JOIN word_attribute_edits wae ON ((wae.successor_id = successors.edit_id)))
+          )
+   SELECT DISTINCT successors.origin_id AS word_attribute_edit_id,
+      r.reviewer_id
+     FROM (successors
+       JOIN reviews r ON ((((r.reviewable_type)::text = 'WordAttributeEdit'::text) AND (r.reviewable_id = successors.edit_id))))
+    WHERE (successors.origin_id <> successors.edit_id)
+  UNION
+   SELECT wae.id AS word_attribute_edit_id,
+      r.reviewer_id
+     FROM (word_attribute_edits wae
+       JOIN reviews r ON ((((r.reviewable_type)::text = 'WordAttributeEdit'::text) AND (r.reviewable_id = wae.id))))
+    WHERE (wae.successor_id IS NULL);
+  SQL
 end

--- a/db/views/reviewers_v01.sql
+++ b/db/views/reviewers_v01.sql
@@ -1,0 +1,19 @@
+-- This lists all user IDs who have reviewed a reviewable or any of its parents
+	with recursive successors(origin_id, edit_id) as (
+			select wae.id, wae.id 
+			from word_attribute_edits wae 
+			where successor_id is null
+		union
+			select origin_id, wae.id
+			from successors
+			join word_attribute_edits wae on wae.successor_id = edit_id
+	)
+	select distinct successors.origin_id as word_attribute_edit_id, r.reviewer_id 
+	from successors
+	join reviews r on r.reviewable_type = 'WordAttributeEdit' and r.reviewable_id = edit_id
+	where origin_id != edit_id
+union
+	select wae.id, r.reviewer_id 
+	from word_attribute_edits wae
+	join reviews r on r.reviewable_type = 'WordAttributeEdit' and r.reviewable_id = wae.id
+	where successor_id is null

--- a/spec/factories/word_attribute_edits.rb
+++ b/spec/factories/word_attribute_edits.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :word_attribute_edit do
+    word factory: :noun
+    attribute_name { "case_1_plural" }
+    value { "Katzen" }
+    state { "waiting_for_review" }
+  end
+end

--- a/spec/features/reviews_spec.rb
+++ b/spec/features/reviews_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "reviews" do
+  let(:me) { create :admin }
+  let(:other_admin) { create :admin }
+
+  it "confirms a change" do
+    edit = create(:word_attribute_edit)
+    expect(edit.reload.current_value).not_to eq edit.proposed_value
+
+    login_as me
+    visit reviews_path
+    expect(page).to have_content edit.word.name
+    click_on I18n.t("reviews.show.actions.confirm")
+
+    expect(edit.reload.current_value).not_to eq edit.proposed_value
+
+    login_as other_admin
+    visit reviews_path
+    expect(page).to have_content edit.word.name
+    click_on I18n.t("reviews.show.actions.confirm")
+
+    expect(edit.reload.current_value).to eq edit.proposed_value
+  end
+
+  it "skips a change" do
+    edit = create(:word_attribute_edit)
+    expect(edit.reload.current_value).not_to eq edit.proposed_value
+
+    login_as me
+    visit reviews_path
+    expect(page).to have_content edit.word.name
+    click_on I18n.t("reviews.show.actions.skip")
+
+    visit reviews_path
+    expect(page).to have_content I18n.t("reviews.index.empty.title")
+    expect(edit.reload.current_value).not_to eq edit.proposed_value
+
+    login_as other_admin
+    visit reviews_path
+    expect(page).to have_content edit.word.name
+    click_on I18n.t("reviews.show.actions.confirm")
+
+    expect(edit.reload.current_value).not_to eq edit.proposed_value
+
+    login_as create(:admin)
+    visit reviews_path
+    expect(page).to have_content edit.word.name
+    click_on I18n.t("reviews.show.actions.confirm")
+
+    expect(edit.reload.current_value).to eq edit.proposed_value
+  end
+
+  it "edits a change" do
+    edit = create(:word_attribute_edit)
+    proposal = "New word"
+    expect(edit.reload.current_value).not_to eq edit.proposed_value
+
+    login_as me
+    visit reviews_path
+    expect(page).to have_content edit.word.name
+    click_on I18n.t("reviews.show.actions.edit")
+
+    fill_in I18n.t("reviews.new.new_proposal"), with: proposal
+    click_on I18n.t("helpers.submit.update")
+    expect(edit.reload.current_value).not_to eq proposal
+
+    login_as other_admin
+    visit reviews_path
+    expect(page).to have_content proposal
+    click_on I18n.t("reviews.show.actions.confirm")
+
+    expect(edit.reload.current_value).not_to eq proposal
+
+    login_as create(:admin)
+    visit reviews_path
+    expect(page).to have_content proposal
+    click_on I18n.t("reviews.show.actions.confirm")
+
+    expect(edit.reload.current_value).to eq proposal
+  end
+
+  it "edits a partially approved change" do
+    edit = create(:word_attribute_edit)
+    proposal = "New word"
+    expect(edit.reload.current_value).not_to eq edit.proposed_value
+
+    login_as me
+    visit reviews_path
+    expect(page).to have_content edit.word.name
+    click_on I18n.t("reviews.show.actions.confirm")
+
+    visit reviews_path
+    expect(page).to have_content I18n.t("reviews.index.empty.title")
+
+    login_as other_admin
+    visit reviews_path
+    expect(page).to have_content edit.word.name
+    click_on I18n.t("reviews.show.actions.edit")
+
+    fill_in I18n.t("reviews.new.new_proposal"), with: proposal
+    click_on I18n.t("helpers.submit.update")
+    expect(edit.reload.current_value).not_to eq proposal
+
+    login_as me
+    visit reviews_path
+    expect(page).to have_content I18n.t("reviews.index.empty.title")
+
+    login_as other_admin
+    visit reviews_path
+    expect(page).to have_content I18n.t("reviews.index.empty.title")
+
+    Reviewable::REVIEWS_REQUIRED.times do
+      login_as create(:admin)
+      visit reviews_path
+      expect(page).to have_content edit.word.name
+      click_on I18n.t("reviews.show.actions.confirm")
+    end
+
+    expect(edit.reload.current_value).to eq proposal
+  end
+end

--- a/spec/models/reviewer_spec.rb
+++ b/spec/models/reviewer_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Reviewer do
+  subject { Reviewer.all }
+
+  let(:me) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:different_user) { create(:user) }
+  let!(:reviewable_skipped_by_other) do
+    create(:word_attribute_edit).tap do |reviewable|
+      reviewable.reviews.create!(reviewer: other_user, state: :skipped)
+    end
+  end
+  let!(:reviewable_fully_confirmed) do
+    create(:word_attribute_edit, state: :confirmed).tap do |reviewable|
+      reviewable.reviews.create!(reviewer: other_user, state: :confirmed)
+      reviewable.reviews.create!(reviewer: different_user, state: :confirmed)
+    end
+  end
+  let!(:reviewable_edited) do
+    create(:word_attribute_edit, state: :edited, successor: reviewable_skipped_by_other).tap do |reviewable|
+      reviewable.reviews.create!(reviewer: me, state: :edited)
+    end
+  end
+  let!(:reviewable_origin) do
+    create(:word_attribute_edit, successor: reviewable_origin_edited).tap do |reviewable|
+      reviewable.reviews.create!(reviewer: me, state: :confirmed)
+    end
+  end
+  let!(:reviewable_origin_edited) do
+    create(:word_attribute_edit, state: :waiting_for_review).tap do |reviewable|
+      reviewable.reviews.create!(reviewer: other_user, state: :edited)
+    end
+  end
+
+  it "includes reviews of parent reviews" do
+    user_ids = {
+      me.id => :me,
+      other_user.id => :other_user,
+      different_user.id => :different_user
+    }
+    reviewable_ids = {
+      reviewable_skipped_by_other.id => :reviewable_skipped_by_other,
+      reviewable_fully_confirmed.id => :reviewable_fully_confirmed,
+      reviewable_edited.id => :reviewable_edited,
+      reviewable_origin.id => :reviewable_origin,
+      reviewable_origin_edited.id => :reviewable_origin_edited
+    }
+
+    symbols = subject.pluck(:word_attribute_edit_id, :reviewer_id).map do |reviewable_id, user_id|
+      [
+        reviewable_ids[reviewable_id],
+        user_ids[user_id]
+      ]
+    end
+
+    expect(symbols).to match_array [
+      [:reviewable_skipped_by_other, :other_user],
+      [:reviewable_skipped_by_other, :me],
+      [:reviewable_fully_confirmed, :other_user],
+      [:reviewable_fully_confirmed, :different_user],
+      [:reviewable_origin_edited, :me],
+      [:reviewable_origin_edited, :other_user]
+    ]
+  end
+end

--- a/spec/models/word_attribute_edit_spec.rb
+++ b/spec/models/word_attribute_edit_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe WordAttributeEdit do
+  describe ".reviewable" do
+    subject { described_class.reviewable(me.id) }
+
+    let(:me) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:different_user) { create(:user) }
+    let!(:reviewable_without_reviews) { create(:word_attribute_edit) }
+    let!(:reviewable_skipped_by_other) do
+      create(:word_attribute_edit).tap do |reviewable|
+        reviewable.reviews.create!(reviewer: other_user, state: :skipped)
+      end
+    end
+    let!(:reviewable_confirmed_by_other) do
+      create(:word_attribute_edit).tap do |reviewable|
+        reviewable.reviews.create!(reviewer: other_user, state: :confirmed)
+      end
+    end
+    let!(:reviewable_skipped_by_me) do
+      create(:word_attribute_edit).tap do |reviewable|
+        reviewable.reviews.create!(reviewer: me, state: :skipped)
+      end
+    end
+    let!(:reviewable_confirmed_by_me) do
+      create(:word_attribute_edit).tap do |reviewable|
+        reviewable.reviews.create!(reviewer: me, state: :confirmed)
+      end
+    end
+    let!(:reviewable_fully_confirmed) do
+      create(:word_attribute_edit, state: :confirmed).tap do |reviewable|
+        reviewable.reviews.create!(reviewer: other_user, state: :confirmed)
+        reviewable.reviews.create!(reviewer: different_user, state: :confirmed)
+      end
+    end
+    let!(:reviewable_successor) { create(:word_attribute_edit, state: :waiting_for_review) }
+    let!(:reviewable_edited) do
+      create(:word_attribute_edit, state: :edited, successor: reviewable_successor).tap do |reviewable|
+        reviewable.reviews.create!(reviewer: me, state: :edited)
+      end
+    end
+
+    it "returns the correct reviewables" do
+      expect(reviewable_without_reviews.confirmed_review_count).to eq 0
+      expect(reviewable_skipped_by_other.confirmed_review_count).to eq 0
+      expect(reviewable_confirmed_by_other.confirmed_review_count).to eq 1
+      expect(reviewable_skipped_by_me.confirmed_review_count).to eq 0
+      expect(reviewable_confirmed_by_me.confirmed_review_count).to eq 1
+      expect(reviewable_fully_confirmed.confirmed_review_count).to eq 2
+      expect(reviewable_successor.confirmed_review_count).to eq 0
+      expect(reviewable_edited.confirmed_review_count).to eq 0
+
+      ids = {
+        reviewable_without_reviews.id => :reviewable_without_reviews,
+        reviewable_skipped_by_other.id => :reviewable_skipped_by_other,
+        reviewable_confirmed_by_other.id => :reviewable_confirmed_by_other,
+        reviewable_skipped_by_me.id => :reviewable_skipped_by_me,
+        reviewable_confirmed_by_me.id => :reviewable_confirmed_by_me,
+        reviewable_fully_confirmed.id => :reviewable_fully_confirmed,
+        reviewable_successor.id => :reviewable_successor,
+        reviewable_edited.id => :reviewable_edited
+      }
+
+      symbols = subject.pluck(:id).map { |id| ids[id] }
+
+      expect(symbols).to match_array [
+        :reviewable_without_reviews,
+        :reviewable_skipped_by_other,
+        :reviewable_confirmed_by_other
+      ]
+    end
+  end
+
+  describe "#store_review" do
+    subject { reviewable.store_review(reviewer:, state:) }
+
+    let(:reviewable) { create(:word_attribute_edit) }
+
+    it "completes the review with enough reviews" do
+      reviewable.store_review(reviewer: create(:user), state: :skipped)
+      expect(reviewable.state).to eq "waiting_for_review"
+
+      reviewable.store_review(reviewer: create(:user), state: :confirmed)
+      expect(reviewable.state).to eq "waiting_for_review"
+
+      reviewable.store_review(reviewer: create(:user), state: :confirmed)
+      expect(reviewable.state).to eq "confirmed"
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,7 @@ require "capybara/rspec"
 require "capybara/rails"
 require "capybara-screenshot/rspec"
 require "capybara/cuprite"
+require "webmock/rspec"
 
 Capybara.asset_host = "http://localhost:3000"
 Capybara.javascript_driver = :cuprite

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,8 @@ require "capybara-screenshot/rspec"
 require "capybara/cuprite"
 require "webmock/rspec"
 
+WebMock.disable_net_connect!(allow: ["127.0.0.1", "localhost"])
+
 Capybara.asset_host = "http://localhost:3000"
 Capybara.javascript_driver = :cuprite
 Capybara.register_driver(:cuprite) do |app|

--- a/spec/services/llm/enrich_spec.rb
+++ b/spec/services/llm/enrich_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe Llm::Enrich do
+  subject { described_class.new(word:).call }
+
+  let(:word) { create(:noun, case_1_plural:) }
+  let(:meaning) { "Ein Tier mit vier Pfoten." }
+  let(:case_1_plural) { "Katzen" }
+
+  let!(:get_llm_response) do
+    stub_request(:post, "http://localhost:11434/v1/chat/completions")
+      .to_return_json(
+        status: 200,
+        body: {
+          "id" => "chatcmpl-294",
+          "object" => "chat.completion",
+          "created" => 1730551991,
+          "model" => "llama3.1",
+          "system_fingerprint" => "fp_ollama",
+          "choices" => [
+            {
+              "index" => 0,
+              "message" => {
+                "role" => "assistant",
+                "content" => "",
+                "tool_calls" => [
+                  {
+                    "id" => "call_8l8ogtf5",
+                    "type" => "function",
+                    "function" => {
+                      "name" => "Llm::Schema::Noun",
+                      "arguments" => "{\"case_1_plural\":\"#{case_1_plural}\",\"meaning\":\"#{meaning}\"}"
+                    }
+                  }
+                ]
+              },
+              "finish_reason" => "tool_calls"
+            }
+          ],
+          "usage" => {"prompt_tokens" => 606, "completion_tokens" => 95, "total_tokens" => 701}
+        }
+      )
+  end
+
+  it "calls the LLM and stores changed attributes" do
+    expect { subject }
+      .to change(WordLlmEnrichment, :count).by(1)
+      .and change(WordAttributeEdit, :count).by(1)
+
+    expect(WordLlmEnrichment.last).to have_attributes(
+      word:,
+      state: "completed"
+    )
+
+    expect(WordAttributeEdit.all).to match_array [
+      have_attributes(
+        word:,
+        attribute_name: "meaning",
+        value: meaning,
+        state: "waiting_for_review"
+      )
+    ]
+  end
+end

--- a/spec/services/llm/enrich_spec.rb
+++ b/spec/services/llm/enrich_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Llm::Enrich do
   let(:case_1_plural) { "Katzen" }
 
   let!(:get_llm_response) do
-    stub_request(:post, "http://localhost:11434/v1/chat/completions")
+    stub_request(:post, "https://ai.test/v1/chat/completions")
       .to_return_json(
         status: 200,
         body: {


### PR DESCRIPTION
This adds calling the LLM to enrich an attribute and adds a basic review process for that attribute.

Only nouns are currently supported. The LLM can be invoked like this:

```ruby
word = Noun.find_by(name: 'Haus')
Llm::Enrich.new(word:).call
```

If the LLM found a different attribute value, this is stored. If you then visit `/seite/reviews` as an admin, you can review that attribute.

An example of enriching the word meaning:

![image](https://github.com/user-attachments/assets/000352e5-c3f3-4348-824b-5c5c89f27079)

After reviewing, it loads the next review. A message is shown if there are no reviews left:

![image](https://github.com/user-attachments/assets/f48e79d9-2849-4b13-a41e-117830801a00)

To make this work we need to install ollama on the server. The LLM model can be specified in the environment variable `LLM_MODEL` (if not set `llama3.1` is used).