### PR TITLE
Review | Select which attributes to review

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,6 +2,7 @@
 @import 'components/word_header';
 @import 'components/box_grid';
 @import 'components/word_symbol' layer(components);
+@import 'form' layer(components);
 
 @tailwind base;
 @tailwind components;

--- a/app/assets/stylesheets/form.css
+++ b/app/assets/stylesheets/form.css
@@ -1,0 +1,7 @@
+.checkbox label {
+  @apply flex gap-2;
+}
+
+.checkbox input {
+  @apply w-4;
+}

--- a/app/components/user_profile_attributes_component.html.haml
+++ b/app/components/user_profile_attributes_component.html.haml
@@ -40,5 +40,11 @@
       .ml-4.flex-shrink-0
         = edit_button edit_password_path
 
+  - if Ability.new(@user).can? :manage, :review
+    = render(list.add(User.human_attribute_name(:review_attributes))) do
+      .flex.flex-wrap.gap-2
+        = helpers.separate_concat Llm::Attributes.translate(@user.review_attributes) do |attribute|
+          %span= attribute
+
   = render(list.add(User.human_attribute_name(:role))) do
     = @user.role_text

--- a/app/components/user_profile_attributes_component.html.haml
+++ b/app/components/user_profile_attributes_component.html.haml
@@ -46,5 +46,9 @@
         = helpers.separate_concat Llm::Attributes.translate(@user.review_attributes) do |attribute|
           %span= attribute
 
+    = render(list.add(User.human_attribute_name(:review_count))) do
+      .flex.flex-wrap.gap-2
+        = Review.where(reviewer: @user).count
+
   = render(list.add(User.human_attribute_name(:role))) do
     = @user.role_text

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -29,9 +29,11 @@ class ProfilesController < ApplicationController
   end
 
   def user_params
-    params.require(:user)
+    params
+      .require(:user)
       .permit(
-        *current_ability.permitted_attributes(:update, @user)
+        *current_ability.permitted_attributes(:update, @user),
+        review_attributes: []
       )
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -64,7 +64,7 @@ class ReviewsController < ApplicationController
   end
 
   def redirect_to_next_review
-    @next_review = WordAttributeEdit.reviewable(current_user.id).first
+    @next_review = WordAttributeEdit.reviewable(current_user).first
 
     if @next_review
       redirect_to review_path(@next_review)

--- a/app/helpers/word_helper.rb
+++ b/app/helpers/word_helper.rb
@@ -35,6 +35,17 @@ module WordHelper
     end
   end
 
+  def separate_concat(items)
+    return if items.blank?
+
+    content_tag :div, class: "flex flex-wrap gap-2" do
+      items.each.with_index do |item, index|
+        concat content_tag :span, "•", class: "text-gray-400" if index != 0
+        concat item
+      end
+    end
+  end
+
   def any_present?(model, attributes)
     return true unless Rails.configuration.hide_blank_items
 

--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -8,9 +8,14 @@ module Reviewable
   included do
     attr_accessor :action
 
-    scope :reviewable, ->(reviewer_id) {
+    scope :reviewable, ->(reviewer) {
+      reviewer_id = reviewer.id
+
       where(successor_id: nil)
-        .where(state: :waiting_for_review)
+        .where(
+          state: :waiting_for_review,
+          attribute_name: reviewer.review_attributes_without_types
+        )
         .where(
           id: select(:id)
         .where("NOT EXISTS (SELECT 1 FROM reviewers WHERE reviewers.word_attribute_edit_id = word_attribute_edits.id AND reviewers.reviewer_id = ?)", reviewer_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,6 +67,18 @@ class User < ApplicationRecord
       &.learning_group
   end
 
+  def review_attributes=(new_value)
+    write_attribute :review_attributes, (new_value || []).compact_blank
+  end
+
+  def review_attributes_without_types
+    review_attributes.map do |attribute_with_type|
+      _type, attribute = attribute_with_type.split(".")
+
+      attribute
+    end.flatten.uniq
+  end
+
   private
 
   def setup_flashcards

--- a/app/services/llm/attributes.rb
+++ b/app/services/llm/attributes.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Llm
+  class Attributes
+    def self.all
+      {
+        noun: Llm::Schema::Noun.properties
+      }
+    end
+
+    def self.keys_with_types
+      collection.map { |(title, key)| key }
+    end
+
+    def self.collection
+      all.each_with_object([]) do |(type, attributes), array|
+        attributes.each do |attribute|
+          array << [
+            type.to_s.classify.constantize.human_attribute_name(attribute),
+            "#{type}.#{attribute}"
+          ]
+        end
+      end.uniq { |title, key| title }
+    end
+
+    def self.translate(attributes)
+      attributes.map do |attribute_with_type|
+        type, attribute = attribute_with_type.split(".")
+
+        type.to_s.classify.constantize.human_attribute_name(attribute)
+      end.uniq
+    end
+  end
+end

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -7,6 +7,9 @@
     = f.input :avatar
     = f.association :word_view_setting, collection: WordViewSetting.accessible_by(current_ability)
 
+    - if Ability.new(@user).can? :manage, :review
+      = f.input :review_attributes, as: :check_boxes, collection: Llm::Attributes.collection
+
     .mt-4
       = f.submit
       = cancel_button profile_path

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -78,6 +78,7 @@ de:
         role: Rolle
         word_view_setting: Ansichtseinstellung
         review_attributes: Attribute für Review
+        review_count: Anzahl Reviews
       word:
         type: Wortart
         name: Wort

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -77,6 +77,7 @@ de:
         last_name: Nachname
         role: Rolle
         word_view_setting: Ansichtseinstellung
+        review_attributes: Attribute für Review
       word:
         type: Wortart
         name: Wort

--- a/db/migrate/20241115170537_add_review_attributes_to_users.rb
+++ b/db/migrate/20241115170537_add_review_attributes_to_users.rb
@@ -1,0 +1,5 @@
+class AddReviewAttributesToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :review_attributes, :string, array: true, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_08_225727) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_15_170537) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pgcrypto"
@@ -392,6 +392,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_08_225727) do
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.bigint "word_view_setting_id"
+    t.string "review_attributes", default: [], null: false, array: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/features/reviews_spec.rb
+++ b/spec/features/reviews_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "reviews" do
-  let(:me) { create :admin }
-  let(:other_admin) { create :admin }
+  let(:me) { create :admin, review_attributes: Llm::Attributes.keys_with_types }
+  let(:other_admin) { create :admin, review_attributes: Llm::Attributes.keys_with_types }
 
   it "confirms a change" do
     edit = create(:word_attribute_edit)
@@ -45,7 +45,7 @@ RSpec.describe "reviews" do
 
     expect(edit.reload.current_value).not_to eq edit.proposed_value
 
-    login_as create(:admin)
+    login_as create(:admin, review_attributes: Llm::Attributes.keys_with_types)
     visit reviews_path
     expect(page).to have_content edit.word.name
     click_on I18n.t("reviews.show.actions.confirm")
@@ -74,7 +74,7 @@ RSpec.describe "reviews" do
 
     expect(edit.reload.current_value).not_to eq proposal
 
-    login_as create(:admin)
+    login_as create(:admin, review_attributes: Llm::Attributes.keys_with_types)
     visit reviews_path
     expect(page).to have_content proposal
     click_on I18n.t("reviews.show.actions.confirm")
@@ -113,7 +113,7 @@ RSpec.describe "reviews" do
     expect(page).to have_content I18n.t("reviews.index.empty.title")
 
     Reviewable::REVIEWS_REQUIRED.times do
-      login_as create(:admin)
+      login_as create(:admin, review_attributes: Llm::Attributes.keys_with_types)
       visit reviews_path
       expect(page).to have_content edit.word.name
       click_on I18n.t("reviews.show.actions.confirm")

--- a/spec/models/word_attribute_edit_spec.rb
+++ b/spec/models/word_attribute_edit_spec.rb
@@ -2,12 +2,13 @@
 
 RSpec.describe WordAttributeEdit do
   describe ".reviewable" do
-    subject { described_class.reviewable(me.id) }
+    subject { described_class.reviewable(me) }
 
-    let(:me) { create(:user) }
-    let(:other_user) { create(:user) }
-    let(:different_user) { create(:user) }
+    let(:me) { create(:user, review_attributes: ["noun.case_1_plural"]) }
+    let(:other_user) { create(:user, review_attributes: ["noun.case_1_plural"]) }
+    let(:different_user) { create(:user, review_attributes: ["noun.case_1_plural"]) }
     let!(:reviewable_without_reviews) { create(:word_attribute_edit) }
+    let!(:reviewable_with_other_attribute) { create(:word_attribute_edit, attribute_name: "meaning") }
     let!(:reviewable_skipped_by_other) do
       create(:word_attribute_edit).tap do |reviewable|
         reviewable.reviews.create!(reviewer: other_user, state: :skipped)


### PR DESCRIPTION
This allows a user to set the word attributes which should appear in the review.

![image](https://github.com/user-attachments/assets/9404b755-ba5c-477a-a1b9-f1a5c9c8a4a4)

The user then only sees reviews regarding those attributes.