### PR TITLE
Add default value for ollama URL

### DIFF
--- a/app/services/llm/invoke.rb
+++ b/app/services/llm/invoke.rb
@@ -15,14 +15,15 @@ module Llm
           model: ENV["LLM_MODEL"].presence || "llama3.1",
           messages: [{role: "user", content: prompt}]
         },
-        response_model:
+        response_model:,
+        max_retries: 2
       )
     end
 
     private
 
     def client
-      @client ||= Instructor.from_openai(OpenAI::Client).new
+      @client ||= Instructor.from_openai(OpenAI::Client, mode: Instructor::Mode::JSON).new
     end
   end
 end

--- a/config/initializers/open_ai.rb
+++ b/config/initializers/open_ai.rb
@@ -2,6 +2,6 @@ Rails.application.config.to_prepare do
   OpenAI.configuration.uri_base = if Rails.env.test?
     "https://ai.test"
   else
-    ENV["OLLAMA_URL"]
+    ENV["OLLAMA_URL"].presence || "http://localhost:11434/v1"
   end
 end


### PR DESCRIPTION
Adds a default value for the ollama URL because the instructor gem does not seem to have that default. Also sets a retry and a mode parameter, which hopefully improves the responses (they currently fail sometimes due to an unexpected response).