### PR TITLE
LLM improvements

### DIFF
--- a/app/components/user_profile_attributes_component.html.haml
+++ b/app/components/user_profile_attributes_component.html.haml
@@ -45,6 +45,8 @@
       .flex.flex-wrap.gap-2
         = helpers.separate_concat Llm::Attributes.translate(@user.review_attributes) do |attribute|
           %span= attribute
+      .ml-4.flex-shrink-0
+        = edit_button edit_profile_path
 
     = render(list.add(User.human_attribute_name(:review_count))) do
       .flex.flex-wrap.gap-2

--- a/app/models/word_attribute_edit.rb
+++ b/app/models/word_attribute_edit.rb
@@ -8,7 +8,7 @@ class WordAttributeEdit < ApplicationRecord
 
   has_many :reviews, dependent: :destroy, inverse_of: :reviewable
 
-  enumerize :state, in: %i[waiting_for_review edited confirmed], default: :waiting_for_review
+  enumerize :state, in: %i[waiting_for_review edited confirmed invalid], default: :waiting_for_review
 
   def attribute_label
     word.class.human_attribute_name(attribute_name)

--- a/app/models/word_import.rb
+++ b/app/models/word_import.rb
@@ -8,5 +8,5 @@ class WordImport < ApplicationRecord
   validates :word_type, presence: true
 
   enumerize :word_type, in: %i[Noun Verb Adjective FunctionWord]
-  enumerize :state, in: %i[new], default: :new
+  enumerize :state, in: %i[new failed], default: :new
 end

--- a/app/models/word_import.rb
+++ b/app/models/word_import.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class WordImport < ApplicationRecord
+  extend Enumerize
+
+  validates :name, presence: true
+  validates :topic, presence: true
+  validates :word_type, presence: true
+
+  enumerize :word_type, in: %i[Noun Verb Adjective FunctionWord]
+  enumerize :state, in: %i[new], default: :new
+end

--- a/app/services/import/word.rb
+++ b/app/services/import/word.rb
@@ -2,7 +2,7 @@
 
 module Import
   class Word
-    attr_reader :name, :topic, :word_type
+    attr_reader :name, :topic, :word_type, :word_import
 
     def initialize(name:, topic:, word_type:)
       @name = name
@@ -18,12 +18,16 @@ module Import
       existing_words&.each do |existing_word|
         Llm::Enrich.new(word: existing_word).call
       end
+    rescue => e
+      word_import&.update(error: e.full_message)
     end
 
     private
 
     def import_exists?
-      WordImport.exists?(name:, topic:, word_type:)
+      WordImport
+        .where.not(state: :failed)
+        .exists?(name:, topic:, word_type:)
     end
 
     def create_word_import

--- a/app/services/import/word.rb
+++ b/app/services/import/word.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Import
+  class Word
+    attr_reader :name, :topic, :word_type
+
+    def initialize(name:, topic:, word_type:)
+      @name = name
+      @topic = topic
+      @word_type = word_type
+    end
+
+    def call
+      return if import_exists?
+
+      create_word_import
+
+      existing_words&.each do |existing_word|
+        Llm::Enrich.new(word: existing_word).call
+      end
+    end
+
+    private
+
+    def import_exists?
+      WordImport.exists?(name:, topic:, word_type:)
+    end
+
+    def create_word_import
+      @word_import ||= WordImport.create!(name:, topic:, word_type:, state: :new)
+    end
+
+    def existing_words
+      ::Word
+        .joins(:topics)
+        .where(
+          name:,
+          type: word_type,
+          "topics.name": topic
+        )
+    end
+  end
+end

--- a/app/services/llm/enrich.rb
+++ b/app/services/llm/enrich.rb
@@ -63,7 +63,7 @@ module Llm
               word:,
               attribute_name:,
               value:,
-              state: :waiting_for_review
+              state: value.present? ? :waiting_for_review : :invalid
             )
         end
       end

--- a/db/migrate/20241116185919_create_word_imports.rb
+++ b/db/migrate/20241116185919_create_word_imports.rb
@@ -1,0 +1,14 @@
+class CreateWordImports < ActiveRecord::Migration[7.1]
+  def change
+    create_table :word_imports do |t|
+      t.string :name
+      t.string :topic
+      t.string :word_type
+      t.string :state, null: false, default: :new
+
+      t.timestamps
+    end
+
+    add_index :word_imports, [:name, :topic, :word_type]
+  end
+end

--- a/db/migrate/20241116200912_add_errors_to_word_imports.rb
+++ b/db/migrate/20241116200912_add_errors_to_word_imports.rb
@@ -1,0 +1,5 @@
+class AddErrorsToWordImports < ActiveRecord::Migration[7.1]
+  def change
+    add_column :word_imports, :error, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_16_185919) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_16_200912) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pgcrypto"
@@ -431,6 +431,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_16_185919) do
     t.string "state", default: "new", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "error"
     t.index ["name", "topic", "word_type"], name: "index_word_imports_on_name_and_topic_and_word_type"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_15_170537) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_16_185919) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pgcrypto"
@@ -424,6 +424,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_15_170537) do
     t.index ["word_type", "word_id"], name: "index_word_attribute_edits_on_word"
   end
 
+  create_table "word_imports", force: :cascade do |t|
+    t.string "name"
+    t.string "topic"
+    t.string "word_type"
+    t.string "state", default: "new", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "topic", "word_type"], name: "index_word_imports_on_name_and_topic_and_word_type"
+  end
+
   create_table "word_llm_enrichments", force: :cascade do |t|
     t.string "word_type", null: false
     t.bigint "word_id", null: false
@@ -558,6 +568,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_15_170537) do
   add_foreign_key "words", "hierarchies"
   add_foreign_key "words", "postfixes"
   add_foreign_key "words", "prefixes"
+
   create_view "reviewers", sql_definition: <<-SQL
       WITH RECURSIVE successors(origin_id, edit_id) AS (
            SELECT wae.id,

--- a/spec/factories/word_imports.rb
+++ b/spec/factories/word_imports.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :word_import do
+    name { "Katze" }
+    topic { "Tiere" }
+    word_type { "Noun" }
+    state { "new" }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,9 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
+# Uncomment the line below in case you have `--require rails_helper` in the `.rspec` file
+# that will avoid rails generators crashing because migrations haven't been run yet
+return unless Rails.env.test?
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 require "capybara/rspec"

--- a/spec/services/import/word_spec.rb
+++ b/spec/services/import/word_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Import::Word do
+  subject { described_class.new(name:, topic:, word_type:).call }
+
+  let(:name) { "Katze" }
+  let(:topic) { "Tiere" }
+  let(:word_type) { "Noun" }
+
+  context "with an empty database" do
+    it "creates a word import" do
+      expect { subject }
+        .to change(WordImport, :count).by(1)
+
+      expect(WordImport.last).to have_attributes(
+        name:,
+        topic:,
+        word_type:,
+        state: "new"
+      )
+    end
+  end
+
+  context "with the same word import" do
+    let!(:word_import) { create(:word_import, name:, topic:, word_type:) }
+
+    it "does not do anything" do
+      expect { subject }
+        .not_to change(WordImport, :count)
+    end
+  end
+
+  context "with the same word" do
+    let!(:word) { create(:noun, name:, topics: [build(:topic, name: topic)]) }
+
+    it "enriches the word" do
+      expect(Llm::Enrich).to receive(:new).with(word:).and_call_original
+      expect_any_instance_of(Llm::Enrich).to receive(:call)
+
+      expect { subject }
+        .to change(WordImport, :count).by(1)
+    end
+  end
+end

--- a/spec/services/import/word_spec.rb
+++ b/spec/services/import/word_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe Import::Word do
     end
   end
 
+  context "with a failed word import" do
+    let!(:word_import) { create(:word_import, name:, topic:, word_type:, state: :failed) }
+
+    it "creates a word import" do
+      expect { subject }
+        .to change(WordImport, :count).by(1)
+    end
+  end
+
   context "with the same word" do
     let!(:word) { create(:noun, name:, topics: [build(:topic, name: topic)]) }
 


### PR DESCRIPTION
This adds a couple of improvements:

- Do not store empty proposals for attributes from LLM responses
- Fix migration exception when using generators
- Add `WordImport` model to store words which are imported. If the word is already known, the LLM enrichment for that word will be run
- Add edit button for review attributes