### PR TITLE
Review | Topics in words partial

### DIFF
--- a/app/components/word_panel_component.html.haml
+++ b/app/components/word_panel_component.html.haml
@@ -5,6 +5,9 @@
         .flex.items-baseline.gap-1
           - if name?
             = name
+          - elsif prefix?
+            = prefix
+            .text-xl.font-bold= word.name
           - else
             = content
             .text-xl.font-bold= word.name

--- a/app/components/word_panel_component.rb
+++ b/app/components/word_panel_component.rb
@@ -3,6 +3,7 @@
 class WordPanelComponent < ViewComponent::Base
   include ComponentsHelper
 
+  renders_one :prefix
   renders_one :name
   renders_one :description
 

--- a/app/helpers/word_helper.rb
+++ b/app/helpers/word_helper.rb
@@ -30,7 +30,11 @@ module WordHelper
     content_tag :div, class: "flex flex-wrap gap-2" do
       items.each.with_index do |item, index|
         concat content_tag :span, "•", class: "text-gray-400" if index != 0
-        yield item
+        if block_given?
+          yield item
+        else
+          concat item
+        end
       end
     end
   end

--- a/app/views/adjectives/_adjective.html.haml
+++ b/app/views/adjectives/_adjective.html.haml
@@ -1,1 +1,7 @@
-= render WordPanelComponent.new(word: adjective)
+= render WordPanelComponent.new(word: adjective) do |component|
+  - component.with_description do
+    - if local_assigns[:description].present?
+      - if description.is_a?(Array)
+        = separate description
+      - else
+        = description

--- a/app/views/function_words/_function_word.html.haml
+++ b/app/views/function_words/_function_word.html.haml
@@ -1,1 +1,7 @@
-= render WordPanelComponent.new(word: function_word)
+= render WordPanelComponent.new(word: function_word) do |component|
+  - component.with_description do
+    - if local_assigns[:description].present?
+      - if description.is_a?(Array)
+        = separate description
+      - else
+        = description

--- a/app/views/nouns/_noun.html.haml
+++ b/app/views/nouns/_noun.html.haml
@@ -1,3 +1,11 @@
-= render WordPanelComponent.new(word: noun) do
-  - if noun.article_definite.present?
-    .text-xl= noun.article_definite
+= render WordPanelComponent.new(word: noun) do |component|
+  - component.with_prefix do
+    - if noun.article_definite.present?
+      .text-xl= noun.article_definite
+
+  - component.with_description do
+    - if local_assigns[:description].present?
+      - if description.is_a?(Array)
+        = separate description
+      - else
+        = description

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -1,5 +1,5 @@
 .p-4
-  = render @reviewable.word
+  = render @reviewable.word, description: @reviewable.word.meaning.presence || @reviewable.word.topics.map(&:name)
 
   .mt-6= t '.attribute'
   .font-bold.text-lg= @reviewable.attribute_label

--- a/app/views/verbs/_verb.html.haml
+++ b/app/views/verbs/_verb.html.haml
@@ -1,1 +1,7 @@
-= render WordPanelComponent.new(word: verb)
+= render WordPanelComponent.new(word: verb) do |component|
+  - component.with_description do
+    - if local_assigns[:description].present?
+      - if description.is_a?(Array)
+        = separate description
+      - else
+        = description


### PR DESCRIPTION
This adds the topics below the word, when the word has no "meaning" set. If it has, the meaning is shown instead.

New words are imported with a topic, so for those we can show the topic.

![image](https://github.com/user-attachments/assets/9d480659-eda4-4be6-ba56-a5c43dc848f5)
