### PR TITLE
LLM | Discard new word

### DIFF
--- a/app/components/reviews/new_word_component.html.haml
+++ b/app/components/reviews/new_word_component.html.haml
@@ -41,4 +41,7 @@
     = form_tag review_path(change_group), method: :patch, class: 'grow md:grow-0' do
       = hidden_field_tag :state, 'skipped'
       = submit_tag t('reviews.show.actions.skip'), class: 'button outline mt-4'
+    = form_tag review_path(change_group), method: :patch, class: 'grow md:grow-0' do
+      = hidden_field_tag :state, 'discarded'
+      = submit_tag t('reviews.show.actions.discard'), class: 'button outline mt-4'
     %button.button.primary.grow.md:grow-0.mt-4{ type: "submit", form: dom_id(change_group, :edit) }= t 'reviews.new_word_component.create'

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -15,13 +15,17 @@ class ReviewsController < ApplicationController
   end
 
   def update
-    has_skipped = params[:state] == "skipped"
+    has_skipped = %w[skipped discarded].include?(params[:state])
 
     if has_skipped
       @reviewable.store_review(
         reviewer: current_user,
         state: params[:state]
       )
+
+      if @reviewable.new_word.present? && params[:state] == "discarded"
+        ReviewMailer.discarded(@reviewable.new_word).deliver_later if ENV["REVIEW_EXCEPTION_MAIL"].present?
+      end
 
       return redirect_to_next_review
     end

--- a/app/mailers/review_mailer.rb
+++ b/app/mailers/review_mailer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ReviewMailer < ApplicationMailer
+  def discarded(new_word)
+    @new_word = new_word
+
+    mail to: ENV["REVIEW_EXCEPTION_MAIL"], subject: t(".subject", name: @new_word.name)
+  end
+end

--- a/app/models/change_group.rb
+++ b/app/models/change_group.rb
@@ -4,7 +4,7 @@ class ChangeGroup < ApplicationRecord
   extend Enumerize
   include Reviewable
 
-  enumerize :state, in: %i[waiting_for_review edited confirmed invalid created duplicate], default: :waiting_for_review
+  enumerize :state, in: %i[waiting_for_review edited confirmed invalid created duplicate discarded], default: :waiting_for_review
 
   has_many :word_attribute_edits, dependent: :destroy
   has_one :new_word, dependent: :destroy

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -6,5 +6,5 @@ class Review < ApplicationRecord
   belongs_to :reviewable, polymorphic: true
   belongs_to :reviewer, class_name: "User"
 
-  enumerize :state, in: %i[skipped edited confirmed created duplicate]
+  enumerize :state, in: %i[skipped edited confirmed created duplicate discarded]
 end

--- a/app/views/reviews_mailer/discarded.html.haml
+++ b/app/views/reviews_mailer/discarded.html.haml
@@ -1,0 +1,14 @@
+Eine Reviewer:in hat enschieden das folgende Wort nicht aufzunehmen:
+
+%table
+  %tr
+    %td Grundform
+    %td= @new_word.name
+    %td Thema
+    %td= @new_word.topic
+    %td Worttyp
+    %td= @new_word.word_type_text
+    %td LLM Vorschlag Grundform
+    %td= @new_word.llm_name
+    %td LLM Vorschlag Thema
+    %td= @new_word.llm_topic

--- a/config/locales/mailers.de.yml
+++ b/config/locales/mailers.de.yml
@@ -5,3 +5,6 @@ de:
       salutation: 'Hallo %{full_name}'
       invited_to: 'Sie wurden in die Lerngruppe "%{name}" eingeladen.'
       accept: Zu meinen Lerngruppen-Einladungen
+  review_mailer:
+    discarded:
+      subject: 'Wort nicht aufgenommen: %{name}'

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -389,6 +389,7 @@ de:
       proposed_value: Vorschlag
       actions:
         skip: Überspringen
+        discard: Wort nicht aufnehmen
         confirm: Vorschlag bestätigen
 
   word_imports:


### PR DESCRIPTION
This allows a new word in the review to be discarded. We then send an email to the environment variable specified in `REVIEW_EXCEPTION_MAIL`.