### PR TITLE
LLM setup fixes

### DIFF
--- a/app/services/llm/invoke.rb
+++ b/app/services/llm/invoke.rb
@@ -45,7 +45,7 @@ module Llm
 
     def client
       @client ||= Langchain::LLM::Ollama.new(
-        url: ENV["OLLAMA_URL"].presence,
+        url: ENV["OLLAMA_URL"].presence || "http://localhost:11434",
         default_options: {temperature: 0.0, chat_model: model}
       )
     end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -84,6 +84,7 @@ task :deploy do
 
     on :launch do
       command "sudo systemctl restart #{fetch(:user)}"
+      command "sudo systemctl restart #{fetch(:user)}-jobs"
     end
   end
 

--- a/config/initializers/langchain.rb
+++ b/config/initializers/langchain.rb
@@ -1,0 +1,16 @@
+module Langchain
+  module LLM
+    class Ollama < Base
+      private
+
+      def client
+        @client ||= Faraday.new(url: url, headers: auth_headers, request: {timeout: 600, read_timeout: 600}) do |conn|
+          conn.request :json
+          conn.response :json
+          conn.response :raise_error
+          conn.response :logger, Langchain.logger, {headers: true, bodies: true, errors: true}
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
A couple of fixes regarding the LLM setup:

1. Add default ollama URL, if not set via the environment
2. Increased timeout of LLM calls as the default timeout of 60 seconds is not enough on the server (also not locally) for our current prompt
3. Add restart of jobs service after deployment