### PR TITLE
Queues for LLM

### DIFF
--- a/app/jobs/enrich_word_job.rb
+++ b/app/jobs/enrich_word_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class EnrichWordJob < ApplicationJob
+  queue_as :llm
+
   def perform(word_id)
     return if word_id.blank?
 

--- a/app/jobs/import_word_job.rb
+++ b/app/jobs/import_word_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ImportWordJob < ApplicationJob
+  queue_as :llm
+
   def perform(word_type:, name:, topic:, word_import_id:)
     Import::Word.new(
       word_type:,

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,7 @@ module Wortschule
     config.default_app_namespace = "seite"
 
     config.active_job.queue_adapter = :good_job
+    config.good_job.queues = "default:3; llm:1"
     config.good_job.enable_cron = true
     config.good_job.cron = {
       sessions_trim: {

--- a/config/initializers/langchain.rb
+++ b/config/initializers/langchain.rb
@@ -4,7 +4,7 @@ module Langchain
       private
 
       def client
-        @client ||= Faraday.new(url: url, headers: auth_headers, request: {timeout: 600, read_timeout: 600}) do |conn|
+        @client ||= Faraday.new(url: url, headers: auth_headers, request: {timeout: 1800, read_timeout: 1800}) do |conn|
           conn.request :json
           conn.response :json
           conn.response :raise_error


### PR DESCRIPTION
Adds its own job queue for the LLM so that we don't schedule more than one LLM job at the time. Also increases the LLM timeout, because it already took 9min on the server, so 10min might cut it a bit close.