### PR TITLE
Remove JSON schema from LLM request

### DIFF
--- a/app/services/llm/enrich.rb
+++ b/app/services/llm/enrich.rb
@@ -68,18 +68,58 @@ module Llm
 
     def llm_invocation
       @llm_invocation ||= Invoke.new(
-        include_format_instructions: true,
+        include_format_instructions: false,
         response_model:,
         prompt_variables: {
-          input_dataset: response_model.from_word(word).to_json,
-          word: word.name
+          input_dataset: response_model.from_word(word).to_json
         },
         prompt: <<~PROMPT
-          The following JSON includes all the information we have about the German word '{word}'. Please correct and enrich that information. We use your response for students learning German. Please ensure that all your answers are in German and adhere to German grammar rules. You can use the provided JSON as an input, but please answer in a JSON conforming to the JSON schema provided later in this request.
+          You are a highly skilled and knowledgeable German teacher, as well as a native speaker, specializing in teaching children aged 6 to 10 how to write in the German language. Your task is to analyze, correct, and enrich a dataset containing partial information about German words, their meanings, and their grammar properties. Your goal is to suggest values for missing information, correct any existing inaccuracies, and improve the overall quality of the dataset.
+          Below is a structured dataset in JSON format. This dataset may contain incomplete or incorrect information. Your role is to complete, correct, and enrich the dataset while adhering strictly to the provided JSON schema and maintaining the integrity of the content.
 
+          Input Dataset:
           {input_dataset}
 
-          {format_instructions}
+          ### Field Explanations
+          Here are detailed explanations of key fields in the dataset to help you understand their purpose:
+
+          - **`meaning`**: A short description of the word's meaning in German.
+          - **`meaning_long`**: A more detailed explanation of the word, if applicable.
+          - **`syllables`**: The breakdown of the word into its syllables. Each syllable should be separated by a hyphen (e.g., "Abendbrot" → "A-bend-brot").
+          - **`written_syllables`**: Indicates how the word's syllables are written when teaching young learners. It may involve annotations for emphasis.
+          - **`plural`**: The plural form of the word, if applicable.
+          - **`compound`**: Boolean indicating whether the word is a compound word.
+          - **`compound_entities`**: Lists the individual components of a compound word (e.g., "Abendbrot" → ["Abend", "Brot"]).
+          - **`genus`**: Indicates the grammatical gender of the word (`masculine`, `feminine`, or `neuter`).
+          - **`case_X_singular` / `case_X_plural`**: Specifies the word's grammatical cases in singular and plural forms, including the associated articles.
+          - **`example_sentences`**: Example sentences demonstrating the word's use in context.
+          - **`keywords`**: A list of up to 10 associative words or ideas that children might link to the main word.
+          - **`topics`**: Categories or themes to which the word belongs (e.g., "Essen und Trinken").
+
+          Instructions
+          1. Analyze and Correct:
+          - Review the dataset for missing or incomplete fields related to the meaning or grammar properties of the German words.
+          - Identify and correct inaccuracies in the existing data, ensuring it aligns with standard German grammar and vocabulary rules.
+
+          2. Correct and Suggest Missing Values:
+          - Suggest accurate and context-appropriate values for missing information about each German word.
+          - For grammar properties, include relevant details such as part of speech, gender (where applicable), plural forms, case usage, and verb conjugations.
+
+          3.  Adhere to JSON Schema
+          - Ensure the output JSON strictly adheres to the provided JSON schema. Do not add or remove fields that are not specified by the schema.
+          - Validate the structure and formatting of the JSON output to ensure compliance with the schema requirements.
+
+          4. Language Requirements:
+          - All suggested and corrected values must be in the German language and adhere to German grammar rules.
+          - Use vocabulary and explanations that are suitable for teaching children aged 6 to 10.
+
+          5. Consistency and Accuracy:
+          - Ensure all grammar properties and meanings are consistent with the word's usage in German.
+          - Verify that the enriched dataset reflects standard German linguistic rules and is accurate for educational purposes.
+          6. Output Formatting:
+          - Your output must be a JSON value formatted to match the provided schema exactly.
+          - Do not include any extraneous information or commentary outside the JSON structure.
+          - Your response should contain only the corrected and enriched dataset in the specified JSON format.
         PROMPT
       )
     end
@@ -108,7 +148,11 @@ module Llm
 
         groups.each do |attributes|
           attributes.select! do |attribute_name, value|
-            next false if word.send(attribute_name) == value
+            existing_value = word.send(attribute_name)
+            next false if existing_value == value
+            next false if value.is_a?(ActiveSupport::HashWithIndifferentAccess)
+            next false if value.is_a?(ActiveRecord::Relation) && value.sort == existing_value.map(&:name).sort
+            next false if value.is_a?(ActiveRecord::Base) && value == existing_value.name
             next false if WordAttributeEdit.exists?(word:, attribute_name:, value:)
 
             true
@@ -123,6 +167,8 @@ module Llm
           attributes.each do |attribute_name, value|
             filtered_value = Attributes.filter(response_model:, attribute_name:, value:)
             next if filtered_value.nil?
+
+            Rails.logger.info "Create LLM suggestion word=#{word.name} attribute_name=#{attribute_name} value=#{filtered_value}"
 
             WordAttributeEdit.create!(
               change_group:,

--- a/app/services/llm/invoke.rb
+++ b/app/services/llm/invoke.rb
@@ -18,13 +18,11 @@ module Llm
 
       raise "LLM response is empty full_prompt=#{full_prompt}" if llm_response.blank?
 
-      output_parser.parse(llm_response)
-    rescue Langchain::OutputParsers::OutputParserException
-      fix_parser = Langchain::OutputParsers::OutputFixingParser.from_llm(
-        llm: client,
-        parser: output_parser
-      )
-      fix_parser.parse(llm_response)
+      Rails.logger.info "Received LLM response:\n#{llm_response}"
+
+      text = llm_response
+      json = text.include?("```") ? text.strip.split(/```(?:json)?/)[1] : text.strip
+      JSON.parse(json)
     end
 
     def full_prompt

--- a/app/services/llm/schema/base.rb
+++ b/app/services/llm/schema/base.rb
@@ -10,6 +10,7 @@ module Llm
           values = word.send(property)
 
           values = values.map(&:name).sort if values.is_a?(ActiveRecord::Relation)
+          values = values.name if values.is_a?(ActiveRecord::Base)
 
           [property, values]
         end


### PR DESCRIPTION
Changes the LLM prompt and also removes the JSON schema from it. My suspicion is that the JSON schema confuses more than it helps. I get better usable results without it with llama3.1.