### PR TITLE
Change suggestions to be sorted

### DIFF
--- a/app/components/reviews/llm_value_component.rb
+++ b/app/components/reviews/llm_value_component.rb
@@ -40,6 +40,6 @@ class Reviews::LlmValueComponent < ViewComponent::Base
   end
 
   def collection
-    Llm::Attributes.relation_klass(attribute_name)&.values
+    Llm::Attributes.relation_klass(attribute_name)&.values&.sort
   end
 end


### PR DESCRIPTION
This fixes suggestions to be sorted within the autocomplete:

![image](https://github.com/user-attachments/assets/d821ed0e-aba0-48f8-93d1-596c241a5734)
