### PR TITLE
Fix review of keywords

### DIFF
--- a/app/components/reviews/llm_value_component.html.haml
+++ b/app/components/reviews/llm_value_component.html.haml
@@ -10,4 +10,13 @@
       %div= example_sentence
     = form.input :value, as: :hidden
   - else
-    = form.input :value, collection:, selected: value, multiple: true, label: false, input_html: {'data-controller': 'select'}
+    %div(data-controller="toggle-buttons" data-toggle-buttons-fixed-value=value data-toggle-buttons-items-value=collection){ 'data-toggle-buttons-checked-value': form.object.change_group.predecessors.present? ? "true" : "false" }
+      %select.hidden(multiple="multiple" data-toggle-buttons-target="input" name="#{form.object_name}[value][]")
+
+      %template#item-template
+        %button.rounded-lg.border.border-primary.p-2.select-none(type="button" data-action="click->toggle-buttons#toggle")
+
+      .flex.flex-wrap.gap-1(data-toggle-buttons-target="list")
+
+      .mt-4.mb-1= t '.add'
+      %input(type="text" data-toggle-buttons-target="add")

--- a/app/javascript/controllers/toggle_buttons_controller.js
+++ b/app/javascript/controllers/toggle_buttons_controller.js
@@ -1,0 +1,110 @@
+import { Controller } from "@hotwired/stimulus"
+import TomSelect from "tom-select"
+
+// Connects to data-controller="toggle-buttons"
+export default class extends Controller {
+  static targets = [
+    "list",
+    "input",
+    "add"
+  ]
+
+  static values = {
+    items: Array,
+    fixed: Array,
+    checked: Boolean
+  }
+
+  connect() {
+    const self = this
+
+    this.fixedValue.forEach(item => this.addItem(item, this.checkedValue))
+    this.updateButtons()
+
+    let options = {
+      options: this.itemsValue.map(item => ({value: item, text: item})),
+      onItemAdd: function(value) {
+        this.clear(true)
+        this.refreshOptions()
+
+        self.addItem(value, true)
+      }
+    }
+
+    new TomSelect(this.addTarget, {
+      valueField: 'value',
+      ...options
+    })
+    this.addTarget.style.display = 'none'
+  }
+
+  addItem(value, checked) {
+    const template = document.getElementById('item-template')
+    const instance = template.content.cloneNode(true)
+    const attribute = btoa(value)
+
+    instance.querySelector('button').textContent = value
+    instance.querySelector('button').dataset.value = value
+    instance.querySelector('button').dataset.checked = checked
+
+    this.listTarget.appendChild(instance)
+
+    if (checked) {
+      this.activate(value)
+    }
+  }
+
+  toggle(event) {
+    if (event.target.dataset.checked === "true") {
+      this.deactivate(event.target.dataset.value)
+    } else {
+      this.activate(event.target.dataset.value)
+    }
+
+    event.target.dataset.checked = event.target.dataset.checked === "true" ? false : true
+    this.updateButtons()
+  }
+
+  activate(value) {
+    const values = this.valueSet()
+    values.add(value)
+    this.setValues(values)
+  }
+
+  deactivate(value) {
+    const values = this.valueSet()
+    values.delete(value)
+    this.setValues(values)
+  }
+
+  valueSet() {
+    return new Set(Array.from(this.inputTarget.options).map(option => option.value))
+  }
+
+  setValues(set) {
+    this.inputTarget.innerHTML = ""
+    Array.from(set).forEach(value => {
+      const option = document.createElement("option")
+      option.value = value
+      option.selected = "selected"
+      this.inputTarget.appendChild(option)
+    })
+    this.inputTarget.value = Array.from(set).join(",")
+    this.updateButtons()
+  }
+
+  updateButtons() {
+    const activeClasses = ['bg-primary', 'text-white', 'shadow']
+    const inactiveClasses = ['bg-gray-background', 'text-primary']
+
+    this.listTarget.querySelectorAll("button").forEach(button => {
+      if (button.dataset.checked === "true") {
+        inactiveClasses.forEach(klass => button.classList.remove(klass))
+        activeClasses.forEach(klass => button.classList.add(klass))
+      } else {
+        inactiveClasses.forEach(klass => button.classList.add(klass))
+        activeClasses.forEach(klass => button.classList.remove(klass))
+      }
+    })
+  }
+}

--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -26,6 +26,7 @@ module Reviewable
     }
 
     belongs_to :successor, optional: true, class_name: "ChangeGroup"
+    has_many :predecessors, class_name: "ChangeGroup", foreign_key: :successor_id, inverse_of: :successor
 
     has_many :reviews, dependent: :destroy, inverse_of: :reviewable
     has_many :reviewers, dependent: nil

--- a/app/services/llm/enrich.rb
+++ b/app/services/llm/enrich.rb
@@ -165,7 +165,7 @@ module Llm
     end
 
     def all_properties_llm_response
-      @llm_invoke_all_properties.call
+      @llm_invoke_all_properties.call.reject { |key, _| key.to_s == "keywords" }
     end
 
     def keywords_llm_response

--- a/app/services/llm/invoke.rb
+++ b/app/services/llm/invoke.rb
@@ -2,13 +2,14 @@
 
 module Llm
   class Invoke
-    attr_reader :prompt, :prompt_variables, :response_model, :include_format_instructions
+    attr_reader :prompt, :prompt_variables, :response_model, :include_format_instructions, :model
 
-    def initialize(prompt:, prompt_variables:, response_model:, include_format_instructions: true)
+    def initialize(prompt:, prompt_variables:, response_model:, include_format_instructions: true, model: default_model)
       @prompt = prompt
       @prompt_variables = prompt_variables
       @response_model = response_model
       @include_format_instructions = include_format_instructions
+      @model = model
     end
 
     def call
@@ -44,11 +45,11 @@ module Llm
     def client
       @client ||= Langchain::LLM::Ollama.new(
         url: ENV["OLLAMA_URL"].presence || "http://localhost:11434",
-        default_options: {temperature: 0.0, chat_model: model}
+        default_options: {temperature: 0.0, chat_completion_model_name: model}
       )
     end
 
-    def model
+    def default_model
       ENV["LLM_MODEL"].presence || "llama3.1"
     end
 

--- a/app/services/llm/schema/shared.rb
+++ b/app/services/llm/schema/shared.rb
@@ -23,6 +23,7 @@ module Llm
           property :opposites, T::Array[String], description: "Gegenteile dieses Wortes"
           property :rimes, T::Array[String], description: "Wörter, die mit diesem Wort reimen"
           property :example_sentences, T::Array[String], description: "Besipielsätze, die dieses Wort verwenden"
+          property :keywords, T::Array[String], description: "Stichwörter zu diesem Wort"
         RUBY
       end
     end

--- a/config/locales/components.de.yml
+++ b/config/locales/components.de.yml
@@ -25,5 +25,7 @@ de:
       create: Erstellen
     duplicate_words_component:
       choose: Wort wählen
+    llm_value_component:
+      add: "Hinzufügen:"
   request_image_component:
     request: Wort-Illustration beantragen

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -107,6 +107,7 @@ de:
         keywords: Stichwörter
         rimes: Reimwörter
         compound_entities: Bausteine
+        example_sentences: Beispielsätze
       noun:
         name: Grundform
         with_tts: Audio aktiviert

--- a/spec/features/themes_spec.rb
+++ b/spec/features/themes_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "themes for words" do
   let(:klass) { Theme }
-  let(:admin) { create :admin }
+  let(:admin) { create :admin, first_name: "Sarah", last_name: "Muster" }
 
   before do
     login_as admin

--- a/spec/services/llm/enrich_spec.rb
+++ b/spec/services/llm/enrich_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Llm::Enrich do
   let(:word) { create(:noun, case_1_plural:) }
   let!(:topic) { create(:topic) } # We need at least one topic for it to be included in the LLM schema
   let(:meaning) { "Ein Tier mit vier Pfoten." }
+  let(:keywords) { ["Bach", "Ungültiges Stichwort"] }
   let(:case_1_plural) { "Katzen" }
 
   let!(:get_llm_response) do
@@ -17,7 +18,7 @@ RSpec.describe Llm::Enrich do
           created_at: "2024-11-20T21:48:24.480952052Z",
           message: {
             role: "assistant",
-            content: "Hier ist der korrigierte und erweiterte JSON-Inhalt für das deutsche Wort \"Hausbau\":\n\n```json\n{\n  \"id\": 8467,\n  \"hierarchy_id\": null,\"topics\": [],\"compound_entities\": [],\"synonyms\": [],\"opposites\": [],\"keywords\": [],\"rimes\": [],\n  \"created_at\": \"2024-01-19T21:26:41.352+01:00\",\n  \"updated_at\": \"2024-11-17T17:54:33.699+01:00\",\n  \"meaning\": \"#{meaning}\",\n  \"meaning_long\": \"#{word.meaning_long}\",\n  \"prototype\": false,\n  \"foreign\": false,\n  \"compound\": false,\n  \"prefix_id\": null,\n  \"postfix_id\": null,\n  \"name\": \"Hausbau\",\n  \"consonant_vowel\": \"KVVKKVV\",\n  \"syllables\": \"#{word.syllables}\",\n  \"written_syllables\": \"\",\n  \"slug\": \"hausbau\",\n  \"plural\": \"#{case_1_plural}\",\n  \"genus_id\": null,\n  \"genus_masculine_id\": null,\n  \"genus_feminine_id\": null,\n  \"genus_neuter_id\": null,\n  \"case_1_singular\": \"\",\n  \"case_1_plural\": \"#{case_1_plural}\",\n  \"case_2_singular\": \"\",\n  \"case_2_plural\": \"\",\n  \"case_3_singular\": \"\",\n  \"case_3_plural\": \"\",\n  \"case_4_singular\": \"\",\n  \"case_4_plural\": \"\",\n  \"pluraletantum\": false,\n  \"singularetantum\": false,\n  \"participle\": \"\",\n  \"past_participle\": \"\",\n  \"present_singular_1\": \"\",\n  \"present_singular_2\": \"\",\n  \"present_singular_3\": \"\",\n  \"present_plural_1\": \"Häuserbauten\",\n  \"present_plural_2\": \"\",\n  \"present_plural_3\": \"\",\n  \"past_singular_1\": \"\",\n  \"past_singular_2\": \"\",\n  \"past_singular_3\": \"\",\n  \"past_plural_1\": \"Häuserbauten waren\",\n  \"past_plural_2\": \"\",\n  \"past_plural_3\": \"\",\n  \"subjectless\": false,\n  \"perfect_haben\": false,\n  \"perfect_sein\": false,\n  \"imperative_singular\": null,\n  \"imperative_plural\": null,\n  \"modal\": false,\n  \"strong\": false,\n  \"comparative\": \"\",\n  \"superlative\": \"\",\n  \"absolute\": false,\n  \"irregular_declination\": false,\n  \"irregular_comparison\": false,\n  \"function_type\": \"Verbum actionis\",\n  \"example_sentences\": [],\n  \"hit_counter\": 1,\n  \"with_tts\": true,\n  \"cologne_phonetics\": [\"081\"]\n}\n```\n\nIch habe dabei die folgenden Änderungen und Ergänzungen vorgenommen:\n\n- Die Beschreibung des Wortes (meaning) wurde korrigiert und erweitert.\n- Die Bedeutung im langen Text (meaning_long) wurde hinzugefügt, um eine bessere Vorstellung von dem Konzept des Hausbaus zu geben.\n- Der grammatische Status des Wortes (prototype) wurde auf False gesetzt, da es sich nicht um ein Grundwort handelt.\n- Die Kompositität des Wortes (compound) wurde auf True gesetzt, da \"Hausbau\" aus zwei Wörtern besteht.\n- Die Silbentrennung (syllables) wurde hinzugefügt, um eine klare Struktur des Wortes zu zeigen.\n- Die Pluralform (plural) und die Pluraletantum-Eigenschaft (pluraletantum) wurden korrigiert und auf True gesetzt, da \"Hausbau\" im Plural als \"Häuserbauten\" vorhanden ist.\n- Die anderen Felder wurden entweder korrigiert oder auf den Standardwerten belassen, um die Konsistenz zu gewährleisten."
+            content: "Hier ist der korrigierte und erweiterte JSON-Inhalt für das deutsche Wort \"Hausbau\":\n\n```json\n{\n  \"id\": 8467,\n  \"hierarchy_id\": null,\"topics\": [],\"compound_entities\": [],\"synonyms\": [],\"opposites\": [],\"keywords\": #{keywords.inspect},\"rimes\": [],\n  \"created_at\": \"2024-01-19T21:26:41.352+01:00\",\n  \"updated_at\": \"2024-11-17T17:54:33.699+01:00\",\n  \"meaning\": \"#{meaning}\",\n  \"meaning_long\": \"#{word.meaning_long}\",\n  \"prototype\": false,\n  \"foreign\": false,\n  \"compound\": false,\n  \"prefix_id\": null,\n  \"postfix_id\": null,\n  \"name\": \"Hausbau\",\n  \"consonant_vowel\": \"KVVKKVV\",\n  \"syllables\": \"#{word.syllables}\",\n  \"written_syllables\": \"\",\n  \"slug\": \"hausbau\",\n  \"plural\": \"#{case_1_plural}\",\n  \"genus_id\": null,\n  \"genus_masculine_id\": null,\n  \"genus_feminine_id\": null,\n  \"genus_neuter_id\": null,\n  \"case_1_singular\": \"\",\n  \"case_1_plural\": \"#{case_1_plural}\",\n  \"case_2_singular\": \"\",\n  \"case_2_plural\": \"\",\n  \"case_3_singular\": \"\",\n  \"case_3_plural\": \"\",\n  \"case_4_singular\": \"\",\n  \"case_4_plural\": \"\",\n  \"pluraletantum\": false,\n  \"singularetantum\": false,\n  \"participle\": \"\",\n  \"past_participle\": \"\",\n  \"present_singular_1\": \"\",\n  \"present_singular_2\": \"\",\n  \"present_singular_3\": \"\",\n  \"present_plural_1\": \"Häuserbauten\",\n  \"present_plural_2\": \"\",\n  \"present_plural_3\": \"\",\n  \"past_singular_1\": \"\",\n  \"past_singular_2\": \"\",\n  \"past_singular_3\": \"\",\n  \"past_plural_1\": \"Häuserbauten waren\",\n  \"past_plural_2\": \"\",\n  \"past_plural_3\": \"\",\n  \"subjectless\": false,\n  \"perfect_haben\": false,\n  \"perfect_sein\": false,\n  \"imperative_singular\": null,\n  \"imperative_plural\": null,\n  \"modal\": false,\n  \"strong\": false,\n  \"comparative\": \"\",\n  \"superlative\": \"\",\n  \"absolute\": false,\n  \"irregular_declination\": false,\n  \"irregular_comparison\": false,\n  \"function_type\": \"Verbum actionis\",\n  \"example_sentences\": [],\n  \"hit_counter\": 1,\n  \"with_tts\": true,\n  \"cologne_phonetics\": [\"081\"]\n}\n```\n\nIch habe dabei die folgenden Änderungen und Ergänzungen vorgenommen:\n\n- Die Beschreibung des Wortes (meaning) wurde korrigiert und erweitert.\n- Die Bedeutung im langen Text (meaning_long) wurde hinzugefügt, um eine bessere Vorstellung von dem Konzept des Hausbaus zu geben.\n- Der grammatische Status des Wortes (prototype) wurde auf False gesetzt, da es sich nicht um ein Grundwort handelt.\n- Die Kompositität des Wortes (compound) wurde auf True gesetzt, da \"Hausbau\" aus zwei Wörtern besteht.\n- Die Silbentrennung (syllables) wurde hinzugefügt, um eine klare Struktur des Wortes zu zeigen.\n- Die Pluralform (plural) und die Pluraletantum-Eigenschaft (pluraletantum) wurden korrigiert und auf True gesetzt, da \"Hausbau\" im Plural als \"Häuserbauten\" vorhanden ist.\n- Die anderen Felder wurden entweder korrigiert oder auf den Standardwerten belassen, um die Konsistenz zu gewährleisten."
           },
           done_reason: "stop",
           done: true,
@@ -34,8 +35,8 @@ RSpec.describe Llm::Enrich do
   it "calls the LLM and stores changed attributes" do
     expect { subject }
       .to change(WordLlmInvocation, :count).by(1)
-      .and change(WordAttributeEdit, :count).by(1)
-      .and change(ChangeGroup, :count).by(1)
+      .and change(WordAttributeEdit, :count).by(2)
+      .and change(ChangeGroup, :count).by(2)
 
     expect(WordLlmInvocation.last).to have_attributes(
       key: "Noun##{word.id}",
@@ -49,10 +50,16 @@ RSpec.describe Llm::Enrich do
 
     expect(WordAttributeEdit.all).to match_array [
       have_attributes(
-        change_group: ChangeGroup.last,
+        change_group: be_present,
         word:,
         attribute_name: "meaning",
         value: meaning.to_json
+      ),
+      have_attributes(
+        change_group: be_present,
+        word:,
+        attribute_name: "keywords",
+        value: ["Bach"].to_json
       )
     ]
   end
@@ -68,7 +75,7 @@ RSpec.describe Llm::Enrich do
             created_at: "2024-11-20T21:48:24.480952052Z",
             message: {
               role: "assistant",
-              content: "Hier ist der korrigierte und erweiterte JSON-Inhalt für das deutsche Wort \"Hausbau\":\n\n```json\n{\n  \"id\": 8467,\n  \"hierarchy_id\": null,\"topics\": [],\"compound_entities\": [],\"synonyms\": [],\"opposites\": [],\"keywords\": [],\"rimes\": [],\n  \"created_at\": \"2024-01-19T21:26:41.352+01:00\",\n  \"updated_at\": \"2024-11-17T17:54:33.699+01:00\",\n  \"meaning\": \"#{word.meaning}\",\n  \"meaning_long\": \"#{word.meaning_long}\",\n  \"prototype\": false,\n  \"foreign\": false,\n  \"compound\": false,\n  \"prefix_id\": null,\n  \"postfix_id\": null,\n  \"name\": \"Hausbau\",\n  \"consonant_vowel\": \"KVVKKVV\",\n  \"syllables\": \"#{word.syllables}\",\n  \"written_syllables\": \"\",\n  \"slug\": \"hausbau\",\n  \"plural\": \"#{case_1_plural}\",\n  \"genus_id\": null,\n  \"genus_masculine_id\": null,\n  \"genus_feminine_id\": null,\n  \"genus_neuter_id\": null,\n  \"case_1_singular\": \"\",\n  \"case_1_plural\": \"#{case_1_plural}\",\n  \"case_2_singular\": \"\",\n  \"case_2_plural\": \"\",\n  \"case_3_singular\": \"\",\n  \"case_3_plural\": \"\",\n  \"case_4_singular\": \"\",\n  \"case_4_plural\": \"\",\n  \"pluraletantum\": false,\n  \"singularetantum\": true,\n  \"participle\": \"\",\n  \"past_participle\": \"\",\n  \"present_singular_1\": \"\",\n  \"present_singular_2\": \"\",\n  \"present_singular_3\": \"\",\n  \"present_plural_1\": \"Häuserbauten\",\n  \"present_plural_2\": \"\",\n  \"present_plural_3\": \"\",\n  \"past_singular_1\": \"\",\n  \"past_singular_2\": \"\",\n  \"past_singular_3\": \"\",\n  \"past_plural_1\": \"Häuserbauten waren\",\n  \"past_plural_2\": \"\",\n  \"past_plural_3\": \"\",\n  \"subjectless\": false,\n  \"perfect_haben\": false,\n  \"perfect_sein\": false,\n  \"imperative_singular\": null,\n  \"imperative_plural\": null,\n  \"modal\": false,\n  \"strong\": false,\n  \"comparative\": \"\",\n  \"superlative\": \"\",\n  \"absolute\": false,\n  \"irregular_declination\": false,\n  \"irregular_comparison\": false,\n  \"function_type\": \"Verbum actionis\",\n  \"example_sentences\": [\"A\", \"B\"],\n  \"hit_counter\": 1,\n  \"with_tts\": true,\n  \"cologne_phonetics\": [\"081\"]\n}\n```\n\nIch habe dabei die folgenden Änderungen und Ergänzungen vorgenommen:\n\n- Die Beschreibung des Wortes (meaning) wurde korrigiert und erweitert.\n- Die Bedeutung im langen Text (meaning_long) wurde hinzugefügt, um eine bessere Vorstellung von dem Konzept des Hausbaus zu geben.\n- Der grammatische Status des Wortes (prototype) wurde auf False gesetzt, da es sich nicht um ein Grundwort handelt.\n- Die Kompositität des Wortes (compound) wurde auf True gesetzt, da \"Hausbau\" aus zwei Wörtern besteht.\n- Die Silbentrennung (syllables) wurde hinzugefügt, um eine klare Struktur des Wortes zu zeigen.\n- Die Pluralform (plural) und die Pluraletantum-Eigenschaft (pluraletantum) wurden korrigiert und auf True gesetzt, da \"Hausbau\" im Plural als \"Häuserbauten\" vorhanden ist.\n- Die anderen Felder wurden entweder korrigiert oder auf den Standardwerten belassen, um die Konsistenz zu gewährleisten."
+              content: "Hier ist der korrigierte und erweiterte JSON-Inhalt für das deutsche Wort \"Hausbau\":\n\n```json\n{\n  \"id\": 8467,\n  \"hierarchy_id\": null,\"topics\": [],\"compound_entities\": [],\"synonyms\": [],\"opposites\": [],\"keywords\": #{keywords.inspect},\"rimes\": [],\n  \"created_at\": \"2024-01-19T21:26:41.352+01:00\",\n  \"updated_at\": \"2024-11-17T17:54:33.699+01:00\",\n  \"meaning\": \"#{word.meaning}\",\n  \"meaning_long\": \"#{word.meaning_long}\",\n  \"prototype\": false,\n  \"foreign\": false,\n  \"compound\": false,\n  \"prefix_id\": null,\n  \"postfix_id\": null,\n  \"name\": \"Hausbau\",\n  \"consonant_vowel\": \"KVVKKVV\",\n  \"syllables\": \"#{word.syllables}\",\n  \"written_syllables\": \"\",\n  \"slug\": \"hausbau\",\n  \"plural\": \"#{case_1_plural}\",\n  \"genus_id\": null,\n  \"genus_masculine_id\": null,\n  \"genus_feminine_id\": null,\n  \"genus_neuter_id\": null,\n  \"case_1_singular\": \"\",\n  \"case_1_plural\": \"#{case_1_plural}\",\n  \"case_2_singular\": \"\",\n  \"case_2_plural\": \"\",\n  \"case_3_singular\": \"\",\n  \"case_3_plural\": \"\",\n  \"case_4_singular\": \"\",\n  \"case_4_plural\": \"\",\n  \"pluraletantum\": false,\n  \"singularetantum\": true,\n  \"participle\": \"\",\n  \"past_participle\": \"\",\n  \"present_singular_1\": \"\",\n  \"present_singular_2\": \"\",\n  \"present_singular_3\": \"\",\n  \"present_plural_1\": \"Häuserbauten\",\n  \"present_plural_2\": \"\",\n  \"present_plural_3\": \"\",\n  \"past_singular_1\": \"\",\n  \"past_singular_2\": \"\",\n  \"past_singular_3\": \"\",\n  \"past_plural_1\": \"Häuserbauten waren\",\n  \"past_plural_2\": \"\",\n  \"past_plural_3\": \"\",\n  \"subjectless\": false,\n  \"perfect_haben\": false,\n  \"perfect_sein\": false,\n  \"imperative_singular\": null,\n  \"imperative_plural\": null,\n  \"modal\": false,\n  \"strong\": false,\n  \"comparative\": \"\",\n  \"superlative\": \"\",\n  \"absolute\": false,\n  \"irregular_declination\": false,\n  \"irregular_comparison\": false,\n  \"function_type\": \"Verbum actionis\",\n  \"example_sentences\": [\"A\", \"B\"],\n  \"hit_counter\": 1,\n  \"with_tts\": true,\n  \"cologne_phonetics\": [\"081\"]\n}\n```\n\nIch habe dabei die folgenden Änderungen und Ergänzungen vorgenommen:\n\n- Die Beschreibung des Wortes (meaning) wurde korrigiert und erweitert.\n- Die Bedeutung im langen Text (meaning_long) wurde hinzugefügt, um eine bessere Vorstellung von dem Konzept des Hausbaus zu geben.\n- Der grammatische Status des Wortes (prototype) wurde auf False gesetzt, da es sich nicht um ein Grundwort handelt.\n- Die Kompositität des Wortes (compound) wurde auf True gesetzt, da \"Hausbau\" aus zwei Wörtern besteht.\n- Die Silbentrennung (syllables) wurde hinzugefügt, um eine klare Struktur des Wortes zu zeigen.\n- Die Pluralform (plural) und die Pluraletantum-Eigenschaft (pluraletantum) wurden korrigiert und auf True gesetzt, da \"Hausbau\" im Plural als \"Häuserbauten\" vorhanden ist.\n- Die anderen Felder wurden entweder korrigiert oder auf den Standardwerten belassen, um die Konsistenz zu gewährleisten."
             },
             done_reason: "stop",
             done: true,
@@ -85,8 +92,8 @@ RSpec.describe Llm::Enrich do
     it "stores booleans and arrays" do
       expect { subject }
         .to change(WordLlmInvocation, :count).by(1)
-        .and change(WordAttributeEdit, :count).by(2)
-        .and change(ChangeGroup, :count).by(2)
+        .and change(WordAttributeEdit, :count).by(3)
+        .and change(ChangeGroup, :count).by(3)
 
       expect(WordLlmInvocation.last).to have_attributes(
         key: "Noun##{word.id}",
@@ -110,6 +117,12 @@ RSpec.describe Llm::Enrich do
           word:,
           attribute_name: "example_sentences",
           value: "[\"A\",\"B\"]"
+        ),
+        have_attributes(
+          change_group: be_present,
+          word:,
+          attribute_name: "keywords",
+          value: ["Bach"].to_json
         )
       ]
     end


### PR DESCRIPTION
We still need the `keywords` property in the `Word` schemas for proper parsing of the results and comparison to the current values. Also it's otherwise missing in the selection in the profile.

Also adds a missing translation and fixes a flaky spec.