### PR TITLE
Fix display of audio player in Chrome

### DIFF
--- a/app/views/words/_tts.html.haml
+++ b/app/views/words/_tts.html.haml
@@ -2,4 +2,4 @@
 - if word&.audios&.attached?
   - audio = sentence.present? ? word.audio_for_example_sentence(sentence) : word.audio_for_word
   %div(data-controller="medium")
-    %audio.w-full.lg:w-auto(src="#{url_for audio}" controls data-medium-target="mediaElement")
+    %audio.w-full(src="#{url_for audio}" controls data-medium-target="mediaElement")


### PR DESCRIPTION
Closes #650.

Chrome doesn't seem to render audio players with `width: auto` anymore.