### PR TITLE
Add unlisted keywords

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -104,6 +104,7 @@ class ReviewsController < ApplicationController
 
           @reviewable.update!(state: "duplicate")
           @reviewable.new_word.update!(duplicate_word:)
+          @reviewable.new_word.process_unlisted_keywords
 
           return redirect_to_next_review
         end
@@ -136,6 +137,7 @@ class ReviewsController < ApplicationController
 
           @reviewable.update!(state: "created")
           @reviewable.new_word.update!(created_word_id: created_word.id)
+          @reviewable.new_word.process_unlisted_keywords
 
           EnrichWordJob.perform_later(created_word.id)
 

--- a/app/models/new_word.rb
+++ b/app/models/new_word.rb
@@ -13,4 +13,16 @@ class NewWord < ApplicationRecord
   validates :word_type, presence: true
   validates :name, presence: true
   validates :topic, presence: true
+
+  def process_unlisted_keywords
+    keyword = created_word || duplicate_word
+
+    transaction do
+      UnlistedKeyword.unprocessed.where(new_word: self).find_each do |unlisted|
+        unlisted.word.keywords << keyword
+        unlisted.word.save!
+        unlisted.update!(state: "processed")
+      end
+    end
+  end
 end

--- a/app/models/unlisted_keyword.rb
+++ b/app/models/unlisted_keyword.rb
@@ -1,0 +1,24 @@
+class UnlistedKeyword < ApplicationRecord
+  extend Enumerize
+
+  belongs_to :word, polymorphic: true
+  belongs_to :word_import
+  belongs_to :new_word, optional: true
+
+  enumerize :state, in: %i[new processed]
+
+  after_commit :import, on: :create
+
+  scope :unprocessed, -> { where(state: "new") }
+
+  private
+
+  def import
+    ImportWordJob.perform_later(
+      word_type: word_import.word_type,
+      name: word_import.name,
+      topic: word_import.topic,
+      word_import_id: word_import.id
+    )
+  end
+end

--- a/app/services/import/word.rb
+++ b/app/services/import/word.rb
@@ -40,6 +40,7 @@ module Import
       ActiveRecord::Base.transaction do
         change_group.save!
         new_word.save!
+        UnlistedKeyword.unprocessed.where(word_import:).update_all(new_word_id: new_word.id)
         @word_import.update!(state: :completed)
       end
     rescue => e

--- a/db/migrate/20250225212139_create_unlisted_keywords.rb
+++ b/db/migrate/20250225212139_create_unlisted_keywords.rb
@@ -1,0 +1,12 @@
+class CreateUnlistedKeywords < ActiveRecord::Migration[7.2]
+  def change
+    create_table :unlisted_keywords do |t|
+      t.references :word, null: false, polymorphic: true
+      t.references :word_import, null: false, foreign_key: true
+      t.references :new_word, null: true, foreign_key: true
+      t.string :state, null: false, default: 'new'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_17_180159) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_25_212139) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pgcrypto"
@@ -411,6 +411,19 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_17_180159) do
     t.index ["word_id", "topic_id"], name: "index_topics_words_on_word_id_and_topic_id", unique: true
   end
 
+  create_table "unlisted_keywords", force: :cascade do |t|
+    t.string "word_type", null: false
+    t.bigint "word_id", null: false
+    t.bigint "word_import_id", null: false
+    t.bigint "new_word_id"
+    t.string "state", default: "new", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["new_word_id"], name: "index_unlisted_keywords_on_new_word_id"
+    t.index ["word_import_id"], name: "index_unlisted_keywords_on_word_import_id"
+    t.index ["word_type", "word_id"], name: "index_unlisted_keywords_on_word"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -600,6 +613,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_17_180159) do
   add_foreign_key "new_words", "words", column: "duplicate_word_id"
   add_foreign_key "reviews", "users", column: "reviewer_id"
   add_foreign_key "themes", "users"
+  add_foreign_key "unlisted_keywords", "new_words"
+  add_foreign_key "unlisted_keywords", "word_imports"
   add_foreign_key "users", "word_view_settings"
   add_foreign_key "word_view_settings", "themes", column: "theme_adjective_id"
   add_foreign_key "word_view_settings", "themes", column: "theme_function_word_id"

--- a/spec/features/reviews/unlisted_keywords_spec.rb
+++ b/spec/features/reviews/unlisted_keywords_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "reviews for a new keyword" do
+  include ActiveJob::TestHelper
+
+  let(:me) { create :admin, review_attributes: Llm::Attributes.keys_with_types }
+  let(:other_admin) { create :admin, review_attributes: Llm::Attributes.keys_with_types }
+  let!(:existing_keyword) { create(:noun, name: "Tier", with_tts: false) }
+  let!(:word) { create(:noun, name: "Katze", with_tts: false) }
+  let!(:edit) { create(:word_attribute_edit, word:, attribute_name: "keywords", value: %w[Tier klein].as_json) }
+
+  after do
+    clear_enqueued_jobs
+  end
+
+  let!(:get_llm_response) do
+    stub_request(:post, "https://ai.test/api/chat")
+      .to_return_json(
+        status: 200,
+        body: {
+          model: "llama3.1",
+          created_at: "2024-11-20T21:48:24.480952052Z",
+          message: {
+            role: "assistant",
+            content: '{ "base_form": "klein", "topic": "" }'
+          },
+          done_reason: "stop",
+          done: true,
+          total_duration: 347987332616,
+          load_duration: 19833664,
+          prompt_eval_count: 726,
+          prompt_eval_duration: 350627000,
+          eval_count: 938,
+          eval_duration: 347572054000
+        }
+      )
+  end
+
+  it "adds the new keyword when the change is fully confirmed", :js do
+    expect(edit.reload.current_value).not_to eq edit.proposed_value
+
+    login_as me
+    visit reviews_path
+    expect(page).to have_content edit.word.name
+    within '[data-toggle-buttons-target="list"]' do
+      click_on "Tier"
+      click_on "klein"
+    end
+    click_on I18n.t("reviews.show.actions.confirm")
+
+    expect(edit.reload.current_value).not_to eq edit.proposed_value
+
+    login_as other_admin
+    visit reviews_path
+    expect(page).to have_content edit.word.name
+    within '[data-toggle-buttons-target="list"]' do
+      click_on "Tier"
+      click_on "klein"
+    end
+    expect do
+      click_on I18n.t("reviews.show.actions.confirm")
+    end.to change(UnlistedKeyword, :count).by(1)
+      .and change(WordImport, :count).by(1)
+      .and enqueue_job(ImportWordJob)
+
+    # Only the existing keyword has been updated
+    expect(edit.reload.current_value).to eq "Tier"
+    expect(word.reload.keywords.pluck(:name)).to eq ["Tier"]
+    expect(UnlistedKeyword.all).to match [
+      have_attributes(
+        word:,
+        word_import: WordImport.last,
+        state: "new"
+      )
+    ]
+    expect(WordImport.all).to match [
+      have_attributes(
+        name: "klein",
+        topic: "klein",
+        word_type: "Adjective"
+      )
+    ]
+
+    expect do
+      perform_enqueued_jobs
+    end.to change(NewWord, :count).by(1)
+
+    # Confirm the new word
+    login_as me
+    visit reviews_path
+    expect(page).to have_content "klein"
+    expect do
+      click_on I18n.t("reviews.new_word_component.create")
+    end.to change(UnlistedKeyword.unprocessed, :count).by(-1)
+      .and change(Adjective, :count).by(1)
+
+    expect(UnlistedKeyword.all).to match [
+      have_attributes(
+        word:,
+        word_import: WordImport.last,
+        state: "processed"
+      )
+    ]
+    expect(word.reload.keywords.pluck(:name)).to match_array ["Tier", "klein"]
+  end
+end


### PR DESCRIPTION
Closes #658.

Based on #657.

This adds "unlisted keywords". When a keyword is proposed by the LLM not yet found in the database, an "unlisted keyword" is created. After that it is passed through the existing "new word" process. So the word is checked by the LLM for base form and word type. If that succeeds, it has to be reviewed by a human (to either be added to the database or discarded).

If the new word is approved by a human, it is added to the database. We then check the unlisted keywords and add all pending as keywords to the original words.