### PR TITLE
LLM prompt | Add `meaning` and `topics` to template

### DIFF
--- a/app/services/llm/enrich.rb
+++ b/app/services/llm/enrich.rb
@@ -20,7 +20,9 @@ module Llm
         include_format_instructions: false,
         response_model: all_properties_response_model,
         prompt_variables: {
-          input_dataset: all_properties_response_model.from_word(word).to_json
+          input_dataset: all_properties_response_model.from_word(word).to_json,
+          meaning: word.meaning,
+          topics: word.topics.map(&:name).join(", ")
         },
         prompt: LlmPrompt.find_by(identifier: "all_properties").content
       )
@@ -29,7 +31,9 @@ module Llm
         response_model: keywords_response_model,
         prompt_variables: {
           word: word.name,
-          valid_keywords: Word.where(id: Keyword.distinct.pluck(:keyword_id)).pluck(:name).join(", ")
+          valid_keywords: Word.where(id: Keyword.distinct.pluck(:keyword_id)).pluck(:name).join(", "),
+          meaning: word.meaning,
+          topics: word.topics.map(&:name).join(", ")
         },
         prompt: LlmPrompt.find_by(identifier: "keywords").content
       )

--- a/app/services/llm/invoke.rb
+++ b/app/services/llm/invoke.rb
@@ -29,10 +29,7 @@ module Llm
     def full_prompt
       return @full_prompt if defined?(@full_prompt)
 
-      templated_prompt = Langchain::Prompt::PromptTemplate.new(
-        template: prompt,
-        input_variables: prompt_variables.keys.map(&:to_s) + (include_format_instructions ? ["format_instructions"] : [])
-      )
+      templated_prompt = Langchain::Prompt::PromptTemplate.from_template(prompt)
 
       templated_prompt.format(
         format_instructions: output_parser.get_format_instructions,


### PR DESCRIPTION
Closes #673.

Adds two new variables for the LLM prompt:

1. `{meaning}`:

![image](https://github.com/user-attachments/assets/c9a98bca-ed75-4030-bffe-51b687a71104)

2. `{topics}` (comma separated):

![image](https://github.com/user-attachments/assets/0bf676e1-cd5c-4559-8c78-6cc69e3e2974)

cc @frankjmueller 