### PR TITLE
Reviews | Find all existing keywords

### DIFF
--- a/app/components/reviews/llm_value_component.rb
+++ b/app/components/reviews/llm_value_component.rb
@@ -20,7 +20,23 @@ class Reviews::LlmValueComponent < ViewComponent::Base
   end
 
   def value
-    word_attribute_edit.proposed_value
+    values = word_attribute_edit.proposed_value
+
+    if values.is_a?(Array)
+      values.map do |element|
+        if element.to_i.to_s == element.to_s
+          word = Llm::Attributes.relation_klass(attribute_name).find(element)
+          meaning = word.respond_to?(:meaning) ? word.meaning : nil
+          text = meaning.present? ? "#{word.name} (#{meaning})" : word.name
+
+          {value: element, text:}
+        else
+          {value: element, text: element}
+        end
+      end.to_json
+    else
+      values
+    end
   end
 
   def type
@@ -40,6 +56,6 @@ class Reviews::LlmValueComponent < ViewComponent::Base
   end
 
   def collection
-    Llm::Attributes.relation_klass(attribute_name)&.values&.sort
+    Llm::Attributes.relation_klass(attribute_name)&.collection
   end
 end

--- a/app/javascript/controllers/toggle_buttons_controller.js
+++ b/app/javascript/controllers/toggle_buttons_controller.js
@@ -18,16 +18,16 @@ export default class extends Controller {
   connect() {
     const self = this
 
-    this.fixedValue.forEach(item => this.addItem(item, this.checkedValue))
+    this.fixedValue.forEach(item => this.addItem(item.value, item.text, this.checkedValue))
     this.updateButtons()
 
     let options = {
-      options: this.itemsValue.map(item => ({value: item, text: item})),
-      onItemAdd: function(value) {
+      options: this.itemsValue.map(([value, text]) => ({value, text})),
+      onItemAdd: function(value, item) {
         this.clear(true)
         this.refreshOptions()
 
-        self.addItem(value, true)
+        self.addItem(value, item.innerText, true)
       }
     }
 
@@ -38,12 +38,12 @@ export default class extends Controller {
     this.addTarget.style.display = 'none'
   }
 
-  addItem(value, checked) {
+  addItem(value, text, checked) {
     const template = document.getElementById('item-template')
     const instance = template.content.cloneNode(true)
     const attribute = btoa(value)
 
-    instance.querySelector('button').textContent = value
+    instance.querySelector('button').textContent = text
     instance.querySelector('button').dataset.value = value
     instance.querySelector('button').dataset.checked = checked
 

--- a/app/models/genus.rb
+++ b/app/models/genus.rb
@@ -39,4 +39,8 @@ class Genus < ApplicationRecord
   def self.values
     distinct.pluck(:name)
   end
+
+  def self.collection
+    distinct.order(:name).pluck(:id, :name)
+  end
 end

--- a/app/models/hierarchy.rb
+++ b/app/models/hierarchy.rb
@@ -15,4 +15,8 @@ class Hierarchy < ApplicationRecord
   def self.values
     distinct.pluck(:name)
   end
+
+  def self.collection
+    distinct.order(:name).pluck(:id, :name)
+  end
 end

--- a/app/models/phenomenon.rb
+++ b/app/models/phenomenon.rb
@@ -5,4 +5,8 @@ class Phenomenon < ApplicationRecord
   def self.values
     distinct.pluck(:name).sort
   end
+
+  def self.collection
+    distinct.order(:name).pluck(:id, :name)
+  end
 end

--- a/app/models/postfix.rb
+++ b/app/models/postfix.rb
@@ -5,4 +5,8 @@ class Postfix < ApplicationRecord
   def self.values
     distinct.pluck(:name)
   end
+
+  def self.collection
+    distinct.order(:name).pluck(:id, :name)
+  end
 end

--- a/app/models/prefix.rb
+++ b/app/models/prefix.rb
@@ -9,4 +9,8 @@ class Prefix < ApplicationRecord
   def self.values
     distinct.pluck(:name)
   end
+
+  def self.collection
+    distinct.order(:name).pluck(:id, :name)
+  end
 end

--- a/app/models/strategy.rb
+++ b/app/models/strategy.rb
@@ -7,4 +7,8 @@ class Strategy < ApplicationRecord
   def self.values
     distinct.pluck(:name).sort
   end
+
+  def self.collection
+    distinct.order(:name).pluck(:id, :name)
+  end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -13,4 +13,8 @@ class Topic < ApplicationRecord
   def self.values
     distinct.pluck(:name).sort
   end
+
+  def self.collection
+    distinct.order(:name).pluck(:id, :name)
+  end
 end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -192,6 +192,10 @@ class Word < ApplicationRecord
     distinct.pluck(:name)
   end
 
+  def self.collection
+    distinct.order(:name).pluck(:id, :name)
+  end
+
   private
 
   def set_consonant_vowel

--- a/app/services/llm/attributes.rb
+++ b/app/services/llm/attributes.rb
@@ -40,7 +40,14 @@ module Llm
 
       if type.is_a?(T::Types::TypedArray)
         if relation_klass(attribute_name).present?
-          value.clamped(relation_klass(attribute_name).values)
+          if attribute_name.to_s != "keywords"
+            value.clamped(relation_klass(attribute_name).values)
+          else
+            existing_keywords = Word.where(name: value)
+            new_keywords = value - existing_keywords.map(&:name)
+
+            existing_keywords.map(&:id).map(&:to_s) + new_keywords
+          end
         else
           value
         end
@@ -72,11 +79,11 @@ module Llm
         when "compound_entities", "synonyms", "opposites", "rimes"
           Word.where(name: value)
         when "keywords"
-          listed_keywords = Word.where(name: value)
-          unlisted_keywords = value - listed_keywords.pluck(:name)
+          listed_keywords = value.select { |key| key.to_i.to_s == key.to_s }
+          unlisted_keywords = value - listed_keywords
 
           word.transaction do
-            word.update!(attribute_name => listed_keywords)
+            word.update!(attribute_name => Word.where(id: listed_keywords))
 
             unlisted_keywords.each do |keyword|
               word_type = if keyword[0] == keyword[0].upcase

--- a/app/services/llm/attributes.rb
+++ b/app/services/llm/attributes.rb
@@ -43,7 +43,13 @@ module Llm
           if attribute_name.to_s != "keywords"
             value.clamped(relation_klass(attribute_name).values)
           else
-            existing_keywords = Word.where(name: value)
+            case_insensitive = Rails.application.config.reviews_keywords_search_case_insensitive
+
+            existing_keywords = if case_insensitive
+              Word.where("LOWER(name) IN (?)", value.map(&:downcase))
+            else
+              Word.where(name: value)
+            end
             new_keywords = value - existing_keywords.map(&:name)
 
             existing_keywords.map(&:id).map(&:to_s) + new_keywords

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,5 +56,8 @@ module Wortschule
 
     # Generated accounts use the following domain for their email address
     config.generated_account_domain = "user.wort.schule"
+
+    # In reviews, keywords are searched case-insensitive
+    config.reviews_keywords_search_case_insensitive = true
   end
 end

--- a/spec/features/reviews/keywords_spec.rb
+++ b/spec/features/reviews/keywords_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "reviews for keywords" do
+  let(:me) { create :admin, review_attributes: Llm::Attributes.keys_with_types }
+  let(:other_admin) { create :admin, review_attributes: Llm::Attributes.keys_with_types }
+  let(:word) { create(:noun, name: "Haus") }
+
+  it "confirms a change", :js do
+    edit = create(:word_attribute_edit, attribute_name: "keywords", value: ["Neues Stichwort", word.id.to_s].to_json)
+    expect(edit.word.keywords.map(&:name)).to be_empty
+    expect(edit.reload.current_value).not_to eq edit.proposed_value
+
+    login_as me
+    visit reviews_path
+    expect(page).to have_content edit.word.name
+    click_on "Neues Stichwort"
+    click_on word.name
+    click_on I18n.t("reviews.show.actions.confirm")
+
+    expect(edit.reload.current_value).not_to eq edit.proposed_value
+
+    login_as other_admin
+    visit reviews_path
+    within '[data-toggle-buttons-target="list"]' do
+      expect(page.find_all("button").map(&:text)).to match_array ["Neues Stichwort", word.name]
+    end
+    click_on "Neues Stichwort"
+    click_on word.name
+    expect do
+      click_on I18n.t("reviews.show.actions.confirm")
+    end.to change(Review, :count).by(1)
+      .and change(WordImport, :count).by(1)
+
+    expect(edit.word.keywords.map(&:name)).to match [word.name]
+    expect(WordImport.all).to match_array [
+      have_attributes(
+        name: "Neues Stichwort"
+      )
+    ]
+  end
+
+  it "adds a new keyword during review", :js do
+    keyword = create(:noun, name: "Hase")
+    edit = create(:word_attribute_edit, attribute_name: "keywords", value: ["Neues Stichwort", word.id].to_json)
+    expect(edit.word.keywords.map(&:name)).to be_empty
+    expect(edit.reload.current_value).not_to eq edit.proposed_value
+
+    # First reviewer adds a new keyword
+    login_as me
+    visit reviews_path
+    expect(page).to have_content edit.word.name
+
+    click_on "Neues Stichwort"
+    click_on word.name
+    fill_in "tomselect-1-ts-control", with: keyword.name
+    within ".ts-dropdown" do
+      find(:css, "[data-value=\"#{keyword.id}\"]").click
+    end
+    # Click somewhere to close autocomplete popup
+    click_on "Hase"
+    # Re-enable selection again
+    click_on "Hase"
+    click_on I18n.t("reviews.show.actions.confirm")
+
+    edit = WordAttributeEdit.order(:created_at).last
+    expect(JSON.parse(edit.value)).to match_array ["Neues Stichwort", word.id.to_s, keyword.id.to_s]
+    expect(edit.reload.current_value).not_to eq edit.proposed_value
+
+    # Second reviewer confirms
+    login_as other_admin
+    visit reviews_path
+    within '[data-toggle-buttons-target="list"]' do
+      expect(page.find_all("button").map(&:text)).to match_array ["Neues Stichwort", word.name, keyword.name]
+    end
+    click_on I18n.t("reviews.show.actions.confirm")
+
+    # Third reviewer confirms
+    login_as create(:admin, review_attributes: Llm::Attributes.keys_with_types)
+    visit reviews_path
+    within '[data-toggle-buttons-target="list"]' do
+      expect(page.find_all("button").map(&:text)).to match_array ["Neues Stichwort", word.name, keyword.name]
+    end
+    expect do
+      click_on I18n.t("reviews.show.actions.confirm")
+    end.to change(Review, :count).by(1)
+      .and change(WordImport, :count).by(1)
+
+    # Final checks
+    expect(JSON.parse(edit.reload.value)).to match ["Neues Stichwort", word.id.to_s, keyword.id.to_s]
+    expect(edit.word.keywords.map(&:name)).to match_array [word.name, keyword.name]
+    expect(WordImport.all).to match_array [
+      have_attributes(
+        name: "Neues Stichwort"
+      )
+    ]
+  end
+end

--- a/spec/features/reviews/unlisted_keywords_spec.rb
+++ b/spec/features/reviews/unlisted_keywords_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "reviews for a new keyword" do
   let(:other_admin) { create :admin, review_attributes: Llm::Attributes.keys_with_types }
   let!(:existing_keyword) { create(:noun, name: "Tier", with_tts: false) }
   let!(:word) { create(:noun, name: "Katze", with_tts: false) }
-  let!(:edit) { create(:word_attribute_edit, word:, attribute_name: "keywords", value: %w[Tier klein].as_json) }
+  let!(:edit) { create(:word_attribute_edit, word:, attribute_name: "keywords", value: [existing_keyword.id, "klein"].to_json) }
 
   after do
     clear_enqueued_jobs
@@ -55,10 +55,10 @@ RSpec.describe "reviews for a new keyword" do
     login_as other_admin
     visit reviews_path
     expect(page).to have_content edit.word.name
-    within '[data-toggle-buttons-target="list"]' do
-      click_on "Tier"
-      click_on "klein"
-    end
+    click_on I18n.t("reviews.show.actions.confirm")
+
+    login_as create(:admin, review_attributes: Llm::Attributes.keys_with_types)
+    visit reviews_path
     expect do
       click_on I18n.t("reviews.show.actions.confirm")
     end.to change(UnlistedKeyword, :count).by(1)

--- a/spec/services/llm/attributes_spec.rb
+++ b/spec/services/llm/attributes_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Llm::Attributes do
+  describe ".filter" do
+    let!(:noun) { create(:noun, name: "Spielen") }
+    let!(:verb) { create(:noun, name: "spielen") }
+
+    it "returns matches irrelevant of capitalization" do
+      expect(
+        described_class.filter(
+          response_model: Llm::Schema::Keywords,
+          attribute_name: "keywords",
+          value: ["Spielen"]
+        )
+      ).to match_array [noun.id.to_s, verb.id.to_s]
+    end
+
+    context "with case sensitive search" do
+      before do
+        allow(Rails.application.config).to receive(:reviews_keywords_search_case_insensitive).and_return(false)
+      end
+
+      it "returns only exact matches" do
+        expect(
+          described_class.filter(
+            response_model: Llm::Schema::Keywords,
+            attribute_name: "keywords",
+            value: ["Spielen"]
+          )
+        ).to match_array [noun.id.to_s]
+      end
+    end
+  end
+end

--- a/spec/services/llm/enrich_spec.rb
+++ b/spec/services/llm/enrich_spec.rb
@@ -3,10 +3,11 @@
 RSpec.describe Llm::Enrich do
   subject { described_class.new(word:).call }
 
-  let(:word) { create(:noun, case_1_plural:) }
+  let(:word) { create(:noun, case_1_plural:, name: "Katze") }
+  let!(:existing_keyword) { create(:noun, name: "Tier") }
   let!(:topic) { create(:topic) } # We need at least one topic for it to be included in the LLM schema
   let(:meaning) { "Ein Tier mit vier Pfoten." }
-  let(:keywords) { ["Bach", "Ungültiges Stichwort"] }
+  let(:keywords) { ["Bach", "Tier"] }
   let(:case_1_plural) { "Katzen" }
 
   let!(:get_llm_response) do
@@ -145,13 +146,13 @@ RSpec.describe Llm::Enrich do
         change_group: be_present,
         word:,
         attribute_name: "keywords",
-        value: ["Bach"].to_json
+        value: [existing_keyword.id.to_s, "Bach"].to_json
       )
     ]
   end
 
   context "with booleans and array attributes" do
-    let(:word) { create(:noun, case_1_plural:, singularetantum: false) }
+    let(:word) { create(:noun, case_1_plural:, singularetantum: false, name: "Katze") }
     let!(:get_llm_response) do
       stub_request(:post, "https://ai.test/api/chat")
         .to_return_json(
@@ -208,7 +209,7 @@ RSpec.describe Llm::Enrich do
           change_group: be_present,
           word:,
           attribute_name: "keywords",
-          value: ["Bach"].to_json
+          value: [existing_keyword.id.to_s, "Bach"].to_json
         )
       ]
     end


### PR DESCRIPTION
Closes #676.

This adds distinction of different words to keywords found by the LLM. If the LLM proposed `Spielen`, it returns `spielen` and `Spielen`. The human reviewers can then choose the fitting ones.