### PR TITLE
Word pages | Second edit button

### DIFF
--- a/app/components/theme_component.html.haml
+++ b/app/components/theme_component.html.haml
@@ -3,6 +3,8 @@
 - if !preview
   .flex.flex-col.gap-12.mt-12
     - if helpers.can?(:edit, word)
+      .flex
+        = link_to t('actions.edit'), [:edit, word], data: { turbo_frame: '_top' }, class: 'button primary'
       = render 'shared/versions', model: word
 
     - if helpers.can?(:manage_llm, word) && !Rails.env.test?

--- a/spec/support/crud.rb
+++ b/spec/support/crud.rb
@@ -20,7 +20,7 @@ RSpec.shared_examples "CRUD" do |klass|
       visit public_send(:"#{klass.model_name.plural}_path")
 
       click_on entry.name
-      click_on t("actions.edit")
+      click_on t("actions.edit"), match: :first
       fill_in "#{klass.model_name.singular}[name]", with: "Anderer Name"
       click_on t("helpers.submit.update")
 
@@ -32,7 +32,7 @@ RSpec.shared_examples "CRUD" do |klass|
       visit public_send(:"#{klass.model_name.plural}_path")
 
       click_on entry.name
-      click_on t("actions.edit")
+      click_on t("actions.edit"), match: :first
       fill_in "#{klass.model_name.singular}[name]", with: ""
 
       expect do
@@ -46,7 +46,7 @@ RSpec.shared_examples "CRUD" do |klass|
       visit public_send(:"#{klass.model_name.plural}_path")
 
       click_on entry.name
-      click_on t("actions.edit")
+      click_on t("actions.edit"), match: :first
       click_on t("actions.delete")
 
       expect do


### PR DESCRIPTION
Closes #696.

Adds a second edit button:

![image](https://github.com/user-attachments/assets/47d5edda-3f70-4b10-a66b-54b36b933250)
