### PR TITLE
Add bulk word editor with per-row undo

### DIFF
--- a/app/controllers/bulk_edit_changes_controller.rb
+++ b/app/controllers/bulk_edit_changes_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class BulkEditChangesController < ApplicationController
+  authorize_resource :bulk_edit, class: false
+
+  def undo
+    change = BulkEditChange.includes(:bulk_edit, :word).find(params[:id])
+    raise CanCan::AccessDenied unless change.bulk_edit.undoable_by?(current_user)
+
+    BulkEditService.new(user: current_user).undo_change(change)
+    render partial: "bulk_edits/protocol_changes", locals: {bulk_edit: change.bulk_edit.reload}
+  rescue BulkEditService::AlreadyReverted
+    head :unprocessable_entity
+  end
+end

--- a/app/controllers/bulk_edits_controller.rb
+++ b/app/controllers/bulk_edits_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class BulkEditsController < ApplicationController
+  authorize_resource class: false
+
+  def index
+    @bulk_edits = BulkEdit
+      .recent_first
+      .includes(:user)
+      .page(params[:log_page])
+      .per(20)
+    @pending_count = BulkEdit.where(undone_at: nil).count
+    @search = Forms::BulkEditSearch.new(params)
+    return unless @search.queried?
+
+    @words_total_count = @search.total_count
+    base = @search.results
+    per_page = @search.per_page
+    @per_page = if per_page <= 0
+      0
+    elsif per_page.zero?
+      50
+    else
+      per_page
+    end
+    @words = (@per_page == 0) ? base : base.page(params[:page]).per(@per_page)
+  end
+
+  def create
+    form = Forms::BulkEditForm.new(params, user: current_user)
+    return redirect_with(form, alert: form.errors.full_messages.to_sentence) unless form.valid?
+
+    bulk_edit = BulkEditService.new(user: current_user).execute(**form.to_service_args)
+    if bulk_edit
+      redirect_with(form, notice: t(".success", count: bulk_edit.affected_count))
+    else
+      redirect_with(form, alert: t(".no_changes"))
+    end
+  end
+
+  def undo
+    bulk_edit = BulkEdit.find(params[:id])
+    raise CanCan::AccessDenied unless bulk_edit.undoable_by?(current_user)
+
+    BulkEditService.new(user: current_user).undo(bulk_edit)
+    redirect_to bulk_edits_path(anchor: "protokoll"), notice: t(".success")
+  rescue BulkEditService::AlreadyUndone
+    redirect_to bulk_edits_path(anchor: "protokoll"), alert: t(".already_undone")
+  end
+
+  def details
+    @bulk_edit = BulkEdit.includes(word_changes: :word).find(params[:id])
+    render partial: "protocol_changes", locals: {bulk_edit: @bulk_edit}
+  end
+
+  private
+
+  def redirect_with(form, flash_args)
+    redirect_to bulk_edits_path(form.preserved_search_params), **flash_args
+  end
+end

--- a/app/controllers/concerns/word_filter.rb
+++ b/app/controllers/concerns/word_filter.rb
@@ -3,6 +3,8 @@
 module WordFilter
   extend ActiveSupport::Concern
 
+  SEARCHABLE_FIELDS = %i[name syllables].freeze
+
   class_methods do
     def replace_regex(query)
       squeeze query
@@ -12,6 +14,21 @@ module WordFilter
 
     def squeeze(query)
       query.squeeze(" ").strip
+    end
+
+    # Builds an ILIKE scope from a wildcard pattern. Supports:
+    # - `*` (any chars), `?` (single char)
+    # - `^` prefix (anchored start), `$` suffix (anchored end)
+    # `field` is restricted to SEARCHABLE_FIELDS to prevent SQL injection.
+    def matching_pattern(query, field: :name)
+      raise ArgumentError, "Unsupported field: #{field}" unless SEARCHABLE_FIELDS.include?(field.to_sym)
+      q = squeeze(query.to_s.strip)
+      return all if q.empty?
+      anchored_start = q.start_with?("^")
+      anchored_end = q.end_with?("$")
+      q = replace_regex(q.delete_prefix("^").delete_suffix("$"))
+      pattern = "#{"%" unless anchored_start}#{q}#{"%" unless anchored_end}"
+      where("words.#{field} ILIKE ?", pattern)
     end
 
     def filter_with_conjunction(attribute, options)

--- a/app/form_objects/forms/bulk_edit_form.rb
+++ b/app/form_objects/forms/bulk_edit_form.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Forms
+  class BulkEditForm
+    include ActiveModel::API
+    include ActiveModel::Attributes
+
+    attr_reader :params, :user, :field, :operation, :strategy, :value
+
+    validates :field, presence: true, inclusion: {in: BulkEdit::ALL_FIELDS}
+    validates :operation, presence: true
+    validate :value_normalized
+    validate :word_ids_present
+    validate :word_count_within_limit
+    validate :operation_allowed_for_field
+
+    def initialize(params, user:)
+      @params = params
+      @user = user
+      @field = params[:field].presence
+      @operation = params[:operation].presence
+      @strategy = (BulkEdit::FieldStrategy.for(@field) if BulkEdit::ALL_FIELDS.include?(@field))
+      @value = @strategy&.normalize_input(params[:value])
+    end
+
+    def select_all?
+      ActiveModel::Type::Boolean.new.cast(params[:select_all])
+    end
+
+    def explicit_ids
+      @explicit_ids ||= Array(params[:selected_ids]).map(&:to_i).reject(&:zero?).uniq
+    end
+
+    def word_count
+      @word_count ||= (select_all? ? search.total_count : explicit_ids.size)
+    end
+
+    def word_ids_for_apply
+      @word_ids_for_apply ||= select_all? ? search.results.except(:includes).pluck(:id) : explicit_ids
+    end
+
+    def to_service_args
+      {
+        word_ids: word_ids_for_apply,
+        field: field,
+        operation: operation,
+        value: value,
+        search_query: params[:q].presence,
+        missing_field: search.missing_field
+      }
+    end
+
+    def preserved_search_params
+      search.to_h
+    end
+
+    private
+
+    def search
+      @search ||= Forms::BulkEditSearch.new(params)
+    end
+
+    def value_normalized
+      return unless @strategy
+      errors.add(:value, :blank) if @value.nil?
+    end
+
+    def word_ids_present
+      errors.add(:base, :no_words_selected) if word_count.zero?
+    end
+
+    def word_count_within_limit
+      return if word_count <= BulkEdit::MAX_WORDS_PER_OPERATION
+      errors.add(:base, :too_many_words, max: BulkEdit::MAX_WORDS_PER_OPERATION)
+    end
+
+    def operation_allowed_for_field
+      return unless @strategy && @operation
+      return if @strategy.operations.include?(@operation)
+      errors.add(:operation, :invalid_for_field)
+    end
+  end
+end

--- a/app/form_objects/forms/bulk_edit_search.rb
+++ b/app/form_objects/forms/bulk_edit_search.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Forms
+  class BulkEditSearch
+    WORD_TYPES = %w[Noun Verb Adjective FunctionWord].freeze
+    SEARCH_FIELDS = %w[name syllables].freeze
+
+    attr_reader :q, :search_field, :word_type, :per_page, :missing_field
+
+    def initialize(params)
+      @q = params[:q].to_s.strip
+      @search_field = params[:search_field].presence_in(SEARCH_FIELDS) || "name"
+      @word_type = params[:word_type].presence_in(WORD_TYPES)
+      @per_page = params[:per_page].to_i
+      @missing_field = params[:missing_field].presence_in(BulkEdit::ALL_FIELDS)
+    end
+
+    def queried?
+      q.present? || missing_field.present?
+    end
+
+    def results
+      scope = q.present? ? Word.matching_pattern(q, field: search_field.to_sym) : Word.all
+      scope = scope.where(type: word_type) if word_type
+      scope = BulkEdit::FieldStrategy.for(missing_field).missing_scope(scope) if missing_field
+      scope
+        .includes(:hierarchy, :prefix, :postfix, :phenomenons, :strategies, :topics, :sources)
+        .ordered_lexigraphically
+    end
+
+    def total_count
+      @total_count ||= results.except(:includes).count
+    end
+
+    def to_h
+      {
+        q: @q.presence,
+        search_field: @search_field,
+        word_type: @word_type,
+        per_page: (@per_page.positive? ? @per_page : nil),
+        missing_field: @missing_field
+      }.compact
+    end
+  end
+end

--- a/app/helpers/bulk_edits_helper.rb
+++ b/app/helpers/bulk_edits_helper.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module BulkEditsHelper
+  # Liefert die Feld-Optionen für das Field-Select gruppiert nach Feldtyp (HABTM/belongs_to/boolean).
+  def bulk_edit_field_groups
+    [
+      [t("bulk_edits.field_groups.habtm"), BulkEdit::HABTM_FIELDS.map { |f| [BulkEdit::FieldStrategy.for(f).label, f, {"data-type" => "habtm"}] }],
+      [t("bulk_edits.field_groups.belongs_to"), BulkEdit::BELONGS_TO_FIELDS.map { |f| [BulkEdit::FieldStrategy.for(f).label, f, {"data-type" => "belongs_to"}] }],
+      [t("bulk_edits.field_groups.boolean"), BulkEdit::BOOLEAN_FIELDS.map { |f| [BulkEdit::FieldStrategy.for(f).label, f, {"data-type" => "boolean"}] }]
+    ]
+  end
+
+  # Liefert die Hash der data-* Attribute, die in <tr> für ein Wort gerendert werden.
+  # Jedes Feld bekommt zwei Attribute: data-current-<field> (typisierter Rohwert für Vergleiche)
+  # und data-display-<field> (lokalisierter Anzeige-Text für die adaptive Spalte).
+  def word_row_data(word)
+    data = {word_id: word.id}
+    BulkEdit::ALL_FIELDS.each do |field|
+      strategy = BulkEdit::FieldStrategy.for(field)
+      data["current_#{field}"] = strategy.current_value(word).to_json
+      data["display_#{field}"] = strategy.display_current(word)
+    end
+    data
+  end
+
+  def operation_badge_class(operation)
+    case operation
+    when "add" then "bg-green-100 text-green-800"
+    when "remove" then "bg-red-100 text-red-800"
+    when "set" then "bg-blue-100 text-blue-800"
+    end
+  end
+end

--- a/app/javascript/controllers/bulk_edit_form_controller.js
+++ b/app/javascript/controllers/bulk_edit_form_controller.js
@@ -1,0 +1,285 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Controls the bulk-edit assignment panel:
+// - toggles visibility of operation-wrapper and value-inputs based on the chosen field
+// - disables/enables value-inputs so only the active one is submitted
+// - live-preview: counts how many of the selected words will actually change
+// - smart-default for HABTM: picks "add" or "remove" based on current state
+// - confirm threshold: sets data-turbo-confirm on submit button when affected count is high
+export default class extends Controller {
+  static targets = [
+    "fieldSelect", "operationWrapper", "operationSelect", "valueInput",
+    "previewText", "submitButton", "currentValueCell", "dynamicColumnHeader",
+    "boolUnset", "operationFallback"
+  ]
+  static values = {
+    confirmThreshold: { type: Number, default: 50 },
+    confirmTemplate:  { type: String, default: "" },
+    habtmFields:      { type: Array, default: [] },
+    belongsToFields:  { type: Array, default: [] },
+    booleanFields:    { type: Array, default: [] }
+  }
+
+  connect() {
+    this.userPickedOperation = false
+    this.fieldChanged()
+  }
+
+  // The bulk_select controller emits this when the user selection changes.
+  // Listen on the document for the custom event so we don't need a tight coupling.
+  selectionChanged = () => {
+    this.updatePreview()
+    this.applySmartDefault()
+  }
+
+  initialize() {
+    document.addEventListener("bulk-select:changed", this.selectionChanged)
+  }
+
+  disconnect() {
+    document.removeEventListener("bulk-select:changed", this.selectionChanged)
+  }
+
+  fieldChanged() {
+    this.userPickedOperation = false
+    this.toggleInputs()
+    this.applySmartDefault()
+    this.updateDynamicColumn()
+    this.updatePreview()
+  }
+
+  operationChanged() {
+    this.userPickedOperation = true
+    this.updatePreview()
+  }
+
+  valueChanged() {
+    this.applySmartDefault()
+    this.updatePreview()
+  }
+
+  toggleInputs() {
+    const field = this.fieldSelectTarget.value
+    const type = this.activeFieldType
+
+    if (this.hasOperationWrapperTarget) {
+      this.operationWrapperTarget.style.display = (type === "habtm") ? "" : "none"
+    }
+
+    // Show only the matching value input, disable all others so the form doesn't submit them.
+    this.valueInputTargets.forEach(el => {
+      const matches = el.dataset.field === field
+      el.style.display = matches ? "" : "none"
+      el.querySelectorAll("input, select").forEach(input => {
+        input.disabled = !matches
+      })
+    })
+
+    // For non-HABTM, the operation is implicitly "set" — write to fallback hidden field.
+    if (this.hasOperationFallbackTarget) {
+      this.operationFallbackTarget.disabled = (type === "habtm")
+      if (this.hasOperationSelectTarget) this.operationSelectTarget.disabled = (type !== "habtm")
+    }
+  }
+
+  get activeOption() {
+    const select = this.fieldSelectTarget
+    return select.options[select.selectedIndex]
+  }
+
+  get activeValueInput() {
+    return this.valueInputTargets.find(el => el.dataset.field === this.fieldSelectTarget.value)
+  }
+
+  get activeFieldType() {
+    const field = this.fieldSelectTarget.value
+    if (this.habtmFieldsValue.includes(field)) return "habtm"
+    if (this.belongsToFieldsValue.includes(field)) return "belongs_to"
+    if (this.booleanFieldsValue.includes(field)) return "boolean"
+    return ""
+  }
+
+  // Reads the current desired value from the active value input.
+  // Returns null if no value chosen.
+  readValue() {
+    const input = this.activeValueInput
+    if (!input) return null
+    const type = input.dataset.fieldType
+    if (type === "habtm") {
+      const select = input.querySelector("select")
+      if (!select) return null
+      return Array.from(select.selectedOptions).map(o => parseInt(o.value, 10)).filter(n => !isNaN(n))
+    }
+    if (type === "belongs_to") {
+      const select = input.querySelector("select")
+      const v = select?.value
+      return (v == null || v === "") ? null : parseInt(v, 10)
+    }
+    if (type === "boolean") {
+      const checked = input.querySelector("input[type=radio]:checked")
+      if (!checked || checked.value === "") return null
+      return checked.value === "true"
+    }
+    return null
+  }
+
+  selectedWordIds() {
+    const event = new CustomEvent("bulk-select:request-ids", { detail: {}, bubbles: true })
+    document.dispatchEvent(event)
+    return Array.isArray(event.detail.ids) ? event.detail.ids : []
+  }
+
+  updatePreview() {
+    const field = this.fieldSelectTarget.value
+    if (!field || !this.hasPreviewTextTarget) return
+
+    const value = this.readValue()
+    const ids = this.selectedWordIds()
+    const allMatches = this.element.querySelector("[data-bulk-select-target='selectAllField']")?.value === "1"
+    const operation = this.activeFieldType === "habtm"
+      ? (this.hasOperationSelectTarget ? this.operationSelectTarget.value : "add")
+      : "set"
+
+    const valueChosen = !(value === null || (Array.isArray(value) && value.length === 0))
+    const hasSelection = allMatches || ids.length > 0
+
+    if (!hasSelection || !valueChosen) {
+      this.previewTextTarget.textContent = ""
+      this.setSubmitEnabled(false)
+      this.removeConfirm()
+      return
+    }
+
+    if (allMatches) {
+      const total = parseInt(this.element.dataset.totalMatches || "0", 10)
+      this.previewTextTarget.textContent = total > 0
+        ? this.t("preview_all", { total: total })
+        : this.t("preview_all_unknown", {})
+      this.setSubmitEnabled(total > 0)
+      this.maybeAddConfirm(total)
+      return
+    }
+
+    // Iterate selected rows we have in the DOM. Words on other pages are unknown — assume changes.
+    let willChange = 0
+    let domSeen = 0
+    const idSet = new Set(ids.map(Number))
+    this.element.querySelectorAll("tr[data-word-id]").forEach(row => {
+      const wid = parseInt(row.dataset.wordId, 10)
+      if (!idSet.has(wid)) return
+      domSeen++
+      if (this.rowWouldChange(row, field, value, operation)) willChange++
+    })
+    const unknownOnOtherPages = ids.length - domSeen
+    const totalEffective = willChange + Math.max(0, unknownOnOtherPages)
+
+    this.previewTextTarget.textContent = this.t("preview", {
+      effective: totalEffective,
+      total: ids.length,
+      noop: ids.length - totalEffective
+    })
+
+    this.setSubmitEnabled(totalEffective > 0)
+    this.maybeAddConfirm(totalEffective)
+  }
+
+  rowWouldChange(row, field, value, operation) {
+    const raw = row.dataset[`current${field.split("_").map((s, i) => i === 0 ? s : s[0].toUpperCase() + s.slice(1)).join("")}`]
+    // dataset auto-camelCases — manually convert "current_hierarchy_id" → "currentHierarchyId"
+    const key = "current" + field.split("_").map(p => p[0].toUpperCase() + p.slice(1)).join("")
+    const cur = JSON.parse(row.dataset[key] || "null")
+    const type = this.activeFieldType
+    if (type === "habtm") {
+      const current = Array.isArray(cur) ? cur.map(Number) : []
+      const desired = Array.isArray(value) ? value.map(Number) : []
+      if (operation === "add") return desired.some(v => !current.includes(v))
+      if (operation === "remove") return desired.some(v => current.includes(v))
+      return false
+    }
+    if (type === "belongs_to") {
+      return Number(cur) !== Number(value)
+    }
+    if (type === "boolean") {
+      return Boolean(cur) !== Boolean(value)
+    }
+    return false
+  }
+
+  applySmartDefault() {
+    if (this.userPickedOperation) return
+    if (this.activeFieldType !== "habtm" || !this.hasOperationSelectTarget) return
+
+    const value = this.readValue()
+    if (!Array.isArray(value) || value.length === 0) return
+
+    const ids = this.selectedWordIds()
+    if (ids.length === 0) return
+
+    let withVal = 0
+    let total = 0
+    const idSet = new Set(ids.map(Number))
+    const field = this.fieldSelectTarget.value
+    const key = "current" + field.split("_").map(p => p[0].toUpperCase() + p.slice(1)).join("")
+    this.element.querySelectorAll("tr[data-word-id]").forEach(row => {
+      const wid = parseInt(row.dataset.wordId, 10)
+      if (!idSet.has(wid)) return
+      total++
+      const cur = JSON.parse(row.dataset[key] || "[]")
+      if (value.some(v => cur.includes(v))) withVal++
+    })
+    if (total === 0) return
+
+    const majorityHave = (withVal / total) >= 0.5
+    this.operationSelectTarget.value = majorityHave ? "remove" : "add"
+  }
+
+  updateDynamicColumn() {
+    const field = this.fieldSelectTarget.value
+    if (!field) return
+    const headerLabel = this.activeOption?.text || ""
+    if (this.hasDynamicColumnHeaderTarget) {
+      this.dynamicColumnHeaderTarget.textContent = headerLabel || "—"
+    }
+    const key = "display" + field.split("_").map(p => p[0].toUpperCase() + p.slice(1)).join("")
+    this.element.querySelectorAll("[data-bulk-edit-form-target='currentValueCell']").forEach(cell => {
+      const row = cell.closest("tr")
+      cell.textContent = row?.dataset[key] || ""
+    })
+  }
+
+  setSubmitEnabled(enabled) {
+    this.submitButtonTargets.forEach(btn => {
+      btn.disabled = !enabled
+    })
+  }
+
+  maybeAddConfirm(count) {
+    if (count >= this.confirmThresholdValue && this.confirmTemplateValue) {
+      const msg = this.confirmTemplateValue.replace("%{count}", count)
+      this.submitButtonTargets.forEach(btn => btn.dataset.turboConfirm = msg)
+    } else {
+      this.removeConfirm()
+    }
+  }
+
+  removeConfirm() {
+    this.submitButtonTargets.forEach(btn => delete btn.dataset.turboConfirm)
+  }
+
+  // Minimal i18n helper: looks up translations via data attributes on the form root.
+  // Format strings come from the server via data-bulk-edit-form-* and have %{key} placeholders.
+  t(key, vars) {
+    // Convert snake_case key → camelCase, then prepend "bulkEditFormI18n":
+    //   "preview_all" → "previewAll" → "bulkEditFormI18nPreviewAll" (matches Stimulus' attribute mapping)
+    const camel = key.replace(/_([a-z])/g, (_, c) => c.toUpperCase())
+    const datasetKey = "bulkEditFormI18n" + camel[0].toUpperCase() + camel.slice(1)
+    const tmpl = this.element.dataset[datasetKey]
+    if (!tmpl) {
+      if (key === "preview") return `${vars.effective}/${vars.total} (${vars.noop} no-op)`
+      if (key === "preview_all") return `All ${vars.total} matches`
+      if (key === "preview_all_unknown") return "All matches"
+      return ""
+    }
+    return tmpl.replace(/%\{(\w+)\}/g, (_, k) => vars[k] ?? "")
+  }
+}

--- a/app/javascript/controllers/bulk_protocol_controller.js
+++ b/app/javascript/controllers/bulk_protocol_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Toggles a protocol row's detail panel. The detail row is the *next sibling* in the table
+// (we can't put a div around two <tr>s, so Stimulus targets don't help here).
+// The detail row contains a <turbo-frame> whose src is set lazily on first expand.
+export default class extends Controller {
+  toggle(event) {
+    const button = event.currentTarget
+    const triggerRow = this.element
+    const detailRow = triggerRow.nextElementSibling
+    if (!detailRow) return
+
+    const frame = detailRow.querySelector("turbo-frame")
+    const expanded = detailRow.style.display !== "none"
+
+    if (expanded) {
+      detailRow.style.display = "none"
+      this.rotateChevron(button, false)
+    } else {
+      if (frame && !frame.src) {
+        frame.src = button.dataset.url
+      }
+      detailRow.style.display = ""
+      this.rotateChevron(button, true)
+    }
+  }
+
+  rotateChevron(button, expanded) {
+    const chevron = button.querySelector("svg")
+    if (chevron) chevron.style.transform = expanded ? "rotate(90deg)" : ""
+  }
+}

--- a/app/javascript/controllers/bulk_select_controller.js
+++ b/app/javascript/controllers/bulk_select_controller.js
@@ -1,0 +1,222 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Manages word selection across pagination via sessionStorage.
+// Emits "bulk-select:changed" on document when selection changes.
+// Listens for "bulk-select:request-ids" to expose current selection to other controllers.
+//
+// Targets:
+//   pageSelectAll       — checkbox "select all on this page"
+//   allMatchesButton    — button "select all N matches" (sets select_all=1 hidden field)
+//   checkbox            — per-row word checkboxes (data-word-id required)
+//   count               — top counter element
+//   summary             — text "12 ausgewählt (über 3 Seiten)" in search bar
+//   actionBar           — floating bottom bar
+//   actionBarCount      — counter in the action bar
+//   submitButton        — Apply buttons (top + bottom)
+//   selectAllField      — hidden input <input name="select_all" value="0|1">
+//
+// Values:
+//   storageKey      — sessionStorage key
+//   signature       — JSON-serialized current search signature; mismatch → reset
+//   countTemplate   — string with %{count} placeholder
+export default class extends Controller {
+  static targets = [
+    "pageSelectAll", "allMatchesButton", "checkbox", "count", "summary",
+    "actionBar", "actionBarCount", "submitButton", "selectAllField"
+  ]
+  static values = {
+    storageKey: { type: String, default: "bulk_edit_selection" },
+    signature:  { type: String, default: "" },
+    countTemplate: { type: String, default: "" }
+  }
+
+  initialize() {
+    this.requestHandler = (event) => {
+      event.detail.ids = this.allMatches ? [] : this.idsArray
+    }
+    this.submitEndHandler = (event) => {
+      // After a successful apply, clear the persisted selection so the user starts fresh.
+      // Failures (validation errors) leave the selection intact.
+      if (event.detail?.success && event.target === this.element) this.reset()
+    }
+  }
+
+  connect() {
+    document.addEventListener("bulk-select:request-ids", this.requestHandler)
+    this.element.addEventListener("turbo:submit-end", this.submitEndHandler)
+    this.restoreFromStorage()
+    this.refreshUI()
+  }
+
+  disconnect() {
+    document.removeEventListener("bulk-select:request-ids", this.requestHandler)
+    this.element.removeEventListener("turbo:submit-end", this.submitEndHandler)
+  }
+
+  get idsSet() {
+    if (!this._ids) this._ids = new Set()
+    return this._ids
+  }
+
+  get idsArray() {
+    return Array.from(this.idsSet)
+  }
+
+  get allMatches() {
+    return this.hasSelectAllFieldTarget && this.selectAllFieldTarget.value === "1"
+  }
+
+  // ----- sessionStorage -----
+
+  restoreFromStorage() {
+    try {
+      const raw = sessionStorage.getItem(this.storageKeyValue)
+      if (!raw) return
+      const data = JSON.parse(raw)
+      if (data.signature !== this.signatureValue) {
+        sessionStorage.removeItem(this.storageKeyValue)
+        return
+      }
+      this._ids = new Set(data.ids)
+      if (data.allMatches && this.hasSelectAllFieldTarget) {
+        this.selectAllFieldTarget.value = "1"
+      }
+    } catch (e) {
+      sessionStorage.removeItem(this.storageKeyValue)
+    }
+  }
+
+  persist() {
+    const data = {
+      signature: this.signatureValue,
+      ids: this.idsArray,
+      allMatches: this.allMatches
+    }
+    sessionStorage.setItem(this.storageKeyValue, JSON.stringify(data))
+  }
+
+  // ----- Checkbox handlers -----
+
+  toggleCheckbox(event) {
+    const cb = event.currentTarget
+    const wid = parseInt(cb.dataset.wordId, 10)
+    if (cb.checked) this.idsSet.add(wid)
+    else this.idsSet.delete(wid)
+
+    // Individual click cancels "Alle Treffer"-mode → fall back to explicit selection.
+    if (this.allMatches) this.disableAllMatches()
+
+    this.persist()
+    this.refreshUI()
+    this.emitChanged()
+  }
+
+  togglePage() {
+    const checked = this.pageSelectAllTarget.checked
+    this.checkboxTargets.forEach(cb => {
+      cb.checked = checked
+      const wid = parseInt(cb.dataset.wordId, 10)
+      if (checked) this.idsSet.add(wid)
+      else this.idsSet.delete(wid)
+    })
+    if (this.allMatches && !checked) this.disableAllMatches()
+    this.persist()
+    this.refreshUI()
+    this.emitChanged()
+  }
+
+  toggleAllMatches() {
+    if (!this.hasSelectAllFieldTarget) return
+    if (this.allMatches) {
+      this.disableAllMatches()
+    } else {
+      this.selectAllFieldTarget.value = "1"
+      this.checkboxTargets.forEach(cb => { cb.checked = true; cb.disabled = true })
+    }
+    this.persist()
+    this.refreshUI()
+    this.emitChanged()
+  }
+
+  disableAllMatches() {
+    if (this.hasSelectAllFieldTarget) this.selectAllFieldTarget.value = ""
+    this.checkboxTargets.forEach(cb => { cb.disabled = false })
+  }
+
+  reset() {
+    this.idsSet.clear()
+    if (this.hasSelectAllFieldTarget) this.selectAllFieldTarget.value = ""
+    this.checkboxTargets.forEach(cb => { cb.checked = false; cb.disabled = false })
+    if (this.hasPageSelectAllTarget) this.pageSelectAllTarget.checked = false
+    sessionStorage.removeItem(this.storageKeyValue)
+    this.refreshUI()
+    this.emitChanged()
+  }
+
+  // ----- UI refresh -----
+
+  refreshUI() {
+    // Mark visible checkboxes from sessionStorage.
+    let visibleSelected = 0
+    let visibleTotal = 0
+    this.checkboxTargets.forEach(cb => {
+      visibleTotal++
+      const wid = parseInt(cb.dataset.wordId, 10)
+      const isSel = this.idsSet.has(wid) || this.allMatches
+      cb.checked = isSel
+      cb.disabled = this.allMatches
+      if (isSel) visibleSelected++
+    })
+
+    if (this.hasPageSelectAllTarget) {
+      this.pageSelectAllTarget.checked = visibleSelected > 0 && visibleSelected === visibleTotal
+      this.pageSelectAllTarget.indeterminate = visibleSelected > 0 && visibleSelected < visibleTotal
+      this.pageSelectAllTarget.disabled = this.allMatches
+    }
+
+    let countText
+    if (this.allMatches) {
+      const totalMatches = parseInt(this.element.dataset.totalMatches || "0", 10)
+      countText = this.countTemplateValue.replace("%{count}", String(totalMatches))
+    } else {
+      const n = this.idsArray.length
+      countText = (n === 0) ? "" : this.countTemplateValue.replace("%{count}", String(n))
+    }
+
+    if (this.hasCountTarget) this.countTarget.textContent = countText
+    if (this.hasSummaryTarget) this.summaryTarget.textContent = countText
+    if (this.hasActionBarCountTarget) this.actionBarCountTarget.textContent = countText
+
+    const hasSelection = this.allMatches || this.idsArray.length > 0
+    if (this.hasActionBarTarget) {
+      this.actionBarTarget.classList.toggle("hidden", !hasSelection)
+    }
+
+    // Ensure hidden inputs reflect all selected IDs (across pages, from sessionStorage).
+    this.syncHiddenIds()
+  }
+
+  // Writes one <input type="hidden" name="selected_ids[]" value="..."> per selected ID.
+  // Replaces the previous batch each time so the form always reflects the latest state.
+  syncHiddenIds() {
+    let container = this.element.querySelector("[data-bulk-select-hidden-ids]")
+    if (!container) {
+      container = document.createElement("div")
+      container.dataset.bulkSelectHiddenIds = "true"
+      container.style.display = "none"
+      this.element.appendChild(container)
+    }
+    container.innerHTML = ""
+    this.idsArray.forEach(id => {
+      const input = document.createElement("input")
+      input.type = "hidden"
+      input.name = "selected_ids[]"
+      input.value = String(id)
+      container.appendChild(input)
+    })
+  }
+
+  emitChanged() {
+    document.dispatchEvent(new CustomEvent("bulk-select:changed", { detail: { ids: this.idsArray, allMatches: this.allMatches } }))
+  }
+}

--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Generic tabs controller.
+// Targets:
+//   tab    — clickable tab triggers, each with data-tabs-panel="<id>"
+//   panel  — the panels to show/hide, each with id matching a tab's data-tabs-panel
+// On connect, reads location.hash and activates the matching tab if present.
+// Adds/removes a "tab-active" CSS class on tabs (defined in the host project's CSS).
+export default class extends Controller {
+  static targets = ["tab", "panel"]
+
+  connect() {
+    if (this.tabTargets.length === 0) return
+    const hash = window.location.hash.replace(/^#/, "")
+    const matchingTab = hash && this.tabTargets.find(t => t.dataset.tabsPanel === hash)
+    const panelId = matchingTab?.dataset?.tabsPanel ?? this.tabTargets[0]?.dataset?.tabsPanel
+    this.activate(panelId)
+  }
+
+  switch(event) {
+    event.preventDefault()
+    this.activate(event.currentTarget.dataset.tabsPanel)
+  }
+
+  activate(panelId) {
+    if (!panelId) return
+    const activeTabClasses = ["font-bold", "shadow", "border", "bg-white"]
+    const inactiveTabClasses = ["hover:bg-white"]
+
+    this.tabTargets.forEach(tab => {
+      const isActive = tab.dataset.tabsPanel === panelId
+      activeTabClasses.forEach(c => tab.classList.toggle(c, isActive))
+      inactiveTabClasses.forEach(c => tab.classList.toggle(c, !isActive))
+    })
+
+    this.panelTargets.forEach(panel => {
+      panel.style.display = panel.id === panelId ? "" : "none"
+    })
+  }
+}

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -65,6 +65,8 @@ class Ability
 
         can :crud, WordViewSetting, owner: user
 
+        can :manage, :bulk_edit
+
       when "Admin"
         can :manage, Noun
         can :manage, Verb
@@ -95,6 +97,7 @@ class Ability
         can :manage, :review
         can :manage, :word_import
         can :manage, :keyword_analytics
+        can :manage, :bulk_edit
         can :read, ImageRequest
 
         # User management

--- a/app/models/bulk_edit.rb
+++ b/app/models/bulk_edit.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class BulkEdit < ApplicationRecord
+  belongs_to :user
+  has_many :word_changes, -> { order(:id) }, class_name: "BulkEditChange", dependent: :destroy, inverse_of: :bulk_edit
+
+  HABTM_FIELDS = %w[topics strategies phenomenons sources].freeze
+  BELONGS_TO_FIELDS = %w[hierarchy_id prefix_id postfix_id].freeze
+  BOOLEAN_FIELDS = %w[prototype foreign compound].freeze
+  ALL_FIELDS = (HABTM_FIELDS + BELONGS_TO_FIELDS + BOOLEAN_FIELDS).freeze
+  OPERATIONS = %w[add remove set].freeze
+  MAX_WORDS_PER_OPERATION = 5_000
+
+  validates :operation, inclusion: {in: OPERATIONS}
+  validates :field, inclusion: {in: ALL_FIELDS}
+  validate :operation_allowed_for_field
+
+  scope :recent_first, -> { order(created_at: :desc) }
+  scope :undoable_by, ->(user) {
+    (user.role == "Admin") ? all : where(user_id: user.id)
+  }
+
+  def strategy
+    @strategy ||= BulkEdit::FieldStrategy.for(field)
+  end
+
+  def undone? = undone_at.present?
+
+  def undoable? = !undone?
+
+  def field_label = strategy.label
+
+  def display_intent = strategy.display_value(intent_value)
+
+  def undoable_by?(user)
+    return false unless undoable?
+    user.role == "Admin" || user_id == user.id
+  end
+
+  private
+
+  def operation_allowed_for_field
+    return if field.blank? || operation.blank?
+    return unless ALL_FIELDS.include?(field)
+    errors.add(:operation, :invalid_for_field) unless strategy.operations.include?(operation)
+  end
+end

--- a/app/models/bulk_edit/field_strategy.rb
+++ b/app/models/bulk_edit/field_strategy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module BulkEdit::FieldStrategy
+  class UnknownField < StandardError; end
+
+  def self.for(field)
+    case field
+    when *BulkEdit::HABTM_FIELDS then Habtm.new(field)
+    when *BulkEdit::BELONGS_TO_FIELDS then BelongsTo.new(field)
+    when *BulkEdit::BOOLEAN_FIELDS then Boolean.new(field)
+    else raise UnknownField, field.inspect
+    end
+  end
+end

--- a/app/models/bulk_edit/field_strategy/base.rb
+++ b/app/models/bulk_edit/field_strategy/base.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class BulkEdit::FieldStrategy::Base
+  attr_reader :field
+
+  def initialize(field)
+    @field = field
+  end
+
+  def label = raise NotImplementedError
+
+  def operations = raise NotImplementedError
+
+  def type_token = raise NotImplementedError
+
+  def normalize_input(_raw) = raise NotImplementedError
+
+  def apply(_word, _value, _operation) = raise NotImplementedError
+
+  def revert(_word, _change) = raise NotImplementedError
+
+  def current_value(_word) = raise NotImplementedError
+
+  def display_current(_word) = raise NotImplementedError
+
+  def display_value(_value) = raise NotImplementedError
+
+  def missing_scope(_scope) = raise NotImplementedError
+
+  def none_label = I18n.t("bulk_edits.values.none")
+end

--- a/app/models/bulk_edit/field_strategy/belongs_to.rb
+++ b/app/models/bulk_edit/field_strategy/belongs_to.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class BulkEdit::FieldStrategy::BelongsTo < BulkEdit::FieldStrategy::Base
+  OPERATIONS = %w[set].freeze
+
+  def operations = OPERATIONS
+
+  def type_token = "belongs_to"
+
+  def label = Word.human_attribute_name(@field.delete_suffix("_id"))
+
+  def normalize_input(raw)
+    id = Array(raw).first.presence
+    {"id" => id&.to_i}
+  end
+
+  def apply(word, value, _operation)
+    new_id = value["id"]
+    old_id = word.public_send(@field)
+    return nil if old_id == new_id
+
+    word.update!(@field => new_id)
+    {previous: {"id" => old_id}, applied: {"id" => new_id}}
+  end
+
+  def revert(word, change)
+    word.update!(@field => change.previous_value["id"])
+  end
+
+  def current_value(word) = word.public_send(@field)
+
+  def display_current(word)
+    associated = word.public_send(@field.delete_suffix("_id"))
+    associated&.name || none_label
+  end
+
+  def display_value(value)
+    ref_model.find_by(id: value["id"])&.name || none_label
+  end
+
+  def missing_scope(scope)
+    scope.where(@field => nil)
+  end
+
+  private
+
+  def ref_model = @field.delete_suffix("_id").classify.constantize
+end

--- a/app/models/bulk_edit/field_strategy/boolean.rb
+++ b/app/models/bulk_edit/field_strategy/boolean.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class BulkEdit::FieldStrategy::Boolean < BulkEdit::FieldStrategy::Base
+  OPERATIONS = %w[set].freeze
+
+  def operations = OPERATIONS
+
+  def type_token = "boolean"
+
+  def label = Word.human_attribute_name(@field)
+
+  def normalize_input(raw)
+    raw = raw.first if raw.is_a?(Array)
+    return nil if raw.blank?
+    {"value" => ActiveModel::Type::Boolean.new.cast(raw)}
+  end
+
+  def apply(word, value, _operation)
+    new_v = value["value"]
+    old_v = word.public_send(@field)
+    return nil if old_v == new_v
+
+    word.update!(@field => new_v)
+    {previous: {"value" => old_v}, applied: {"value" => new_v}}
+  end
+
+  def revert(word, change)
+    word.update!(@field => change.previous_value["value"])
+  end
+
+  def current_value(word) = word.public_send(@field)
+
+  def display_current(word) = display_bool(word.public_send(@field))
+
+  def display_value(value) = display_bool(value["value"])
+
+  def missing_scope(scope)
+    scope.where(@field => [nil, false])
+  end
+
+  private
+
+  def display_bool(v)
+    case v
+    when true then I18n.t("simple_form.yes")
+    when false then I18n.t("simple_form.no")
+    else none_label
+    end
+  end
+end

--- a/app/models/bulk_edit/field_strategy/habtm.rb
+++ b/app/models/bulk_edit/field_strategy/habtm.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class BulkEdit::FieldStrategy::Habtm < BulkEdit::FieldStrategy::Base
+  OPERATIONS = %w[add remove].freeze
+
+  def operations = OPERATIONS
+
+  def type_token = "habtm"
+
+  def label = model.model_name.human(count: 2)
+
+  def normalize_input(raw)
+    ids = Array(raw).flat_map { |v| v.is_a?(String) ? v.split(",") : v }
+      .map(&:to_i).reject(&:zero?).uniq
+    return nil if ids.empty?
+    {"ids" => ids}
+  end
+
+  def apply(word, value, operation)
+    requested = Array(value["ids"])
+    existing = current_value(word)
+
+    case operation
+    when "add"
+      delta = requested - existing
+      return nil if delta.empty?
+      model.where(id: delta).each { |m| word.public_send(@field) << m }
+      {previous: {"ids" => []}, applied: {"ids" => delta}}
+    when "remove"
+      delta = requested & existing
+      return nil if delta.empty?
+      word.public_send(@field).delete(model.where(id: delta))
+      {previous: {"ids" => delta}, applied: {"ids" => []}}
+    end
+  end
+
+  def revert(word, change)
+    added = Array(change.applied_value["ids"])
+    removed = Array(change.previous_value["ids"])
+
+    word.public_send(@field).delete(model.where(id: added)) if added.any?
+
+    if removed.any?
+      currently = word.public_send(@field).map(&:id)
+      to_readd = removed - currently
+      model.where(id: to_readd).each { |m| word.public_send(@field) << m } if to_readd.any?
+    end
+  end
+
+  def current_value(word) = word.public_send(@field).map(&:id)
+
+  def display_current(word)
+    names = word.public_send(@field).map(&:name)
+    names.empty? ? none_label : names.join(", ")
+  end
+
+  def display_value(value)
+    ids = Array(value["ids"])
+    return none_label if ids.empty?
+    model.where(id: ids).pluck(:name).join(", ")
+  end
+
+  def missing_scope(scope)
+    scope.where.missing(@field.to_sym)
+  end
+
+  private
+
+  def model = @field.classify.constantize
+end

--- a/app/models/bulk_edit_change.rb
+++ b/app/models/bulk_edit_change.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class BulkEditChange < ApplicationRecord
+  belongs_to :bulk_edit, inverse_of: :word_changes
+  belongs_to :word, optional: true
+
+  scope :pending, -> { where(reverted_at: nil) }
+  scope :reverted, -> { where.not(reverted_at: nil) }
+
+  def reverted? = reverted_at.present?
+end

--- a/app/services/bulk_edit_service.rb
+++ b/app/services/bulk_edit_service.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+class BulkEditService
+  class AlreadyUndone < StandardError; end
+
+  class AlreadyReverted < StandardError; end
+
+  attr_reader :user
+
+  def initialize(user:)
+    @user = user
+  end
+
+  def execute(word_ids:, field:, operation:, value:, search_query: nil, missing_field: nil)
+    strategy = BulkEdit::FieldStrategy.for(field)
+    unless strategy.operations.include?(operation)
+      raise ArgumentError, "Operation #{operation.inspect} not allowed for #{field.inspect}"
+    end
+
+    applied = []
+
+    ActiveRecord::Base.transaction do
+      Word.where(id: word_ids).find_each do |word|
+        word.with_lock do
+          result = strategy.apply(word, value, operation)
+          applied << {word_id: word.id, previous: result[:previous], applied: result[:applied]} if result
+        end
+      end
+
+      # No-Op: keine echte Änderung an irgendeinem Wort → kein leerer Protokoll-Eintrag.
+      next if applied.empty?
+
+      bulk_edit = BulkEdit.create!(
+        user: @user,
+        field: field,
+        operation: operation,
+        intent_value: value,
+        search_query: search_query,
+        missing_field: missing_field,
+        affected_count: applied.size
+      )
+
+      now = Time.current
+      BulkEditChange.insert_all!(
+        applied.map { |c|
+          {
+            bulk_edit_id: bulk_edit.id,
+            word_id: c[:word_id],
+            previous_value: c[:previous],
+            applied_value: c[:applied],
+            created_at: now,
+            updated_at: now
+          }
+        }
+      )
+
+      @result = bulk_edit
+    end
+
+    @result
+  end
+
+  def undo(bulk_edit)
+    raise AlreadyUndone if bulk_edit.undone?
+    strategy = BulkEdit::FieldStrategy.for(bulk_edit.field)
+
+    ActiveRecord::Base.transaction do
+      bulk_edit.word_changes.pending.includes(:word).find_each do |change|
+        revert_one(strategy, change)
+      end
+      bulk_edit.update!(undone_at: Time.current)
+    end
+  end
+
+  def undo_change(change)
+    raise AlreadyReverted if change.reverted?
+    strategy = BulkEdit::FieldStrategy.for(change.bulk_edit.field)
+
+    ActiveRecord::Base.transaction do
+      revert_one(strategy, change)
+      auto_complete_undo(change.bulk_edit)
+    end
+  end
+
+  private
+
+  # Sperrt das Change selbst → zwei parallele Undos serialisieren sich.
+  # Innerhalb der Change-Sperre wird zusätzlich das Word gesperrt.
+  def revert_one(strategy, change)
+    change.with_lock do
+      return if change.reverted?
+      word = change.word
+      if word.nil?
+        Rails.logger.warn("BulkEditChange #{change.id} skipped — word #{change.word_id} not found")
+      else
+        word.with_lock { strategy.revert(word, change) }
+      end
+      change.update!(reverted_at: Time.current)
+    end
+  end
+
+  def auto_complete_undo(bulk_edit)
+    return if bulk_edit.undone?
+    return if bulk_edit.word_changes.pending.exists?
+    bulk_edit.update!(undone_at: Time.current)
+  end
+end

--- a/app/views/bulk_edits/_action_bar.html.haml
+++ b/app/views/bulk_edits/_action_bar.html.haml
@@ -1,0 +1,6 @@
+.fixed.bottom-0.left-0.right-0.bg-white.border-t.border-gray-300.shadow-lg.py-3.px-4.z-40.hidden{data: {bulk_select_target: "actionBar"}}
+  .max-w-7xl.mx-auto.flex.flex-wrap.items-center.gap-4
+    %span.text-sm.font-medium{data: {bulk_select_target: "actionBarCount"}}
+    %button.button.button-sm{type: "button", data: {action: "click->bulk-select#reset"}}= t('bulk_edits.index.clear_selection')
+    .ml-auto
+      = form.submit t('bulk_edits.index.apply'), class: 'button primary', disabled: true, data: {bulk_edit_form_target: "submitButton", bulk_select_target: "submitButton"}

--- a/app/views/bulk_edits/_assignment_panel.html.haml
+++ b/app/views/bulk_edits/_assignment_panel.html.haml
@@ -1,0 +1,25 @@
+.mt-6
+  = box class: "!overflow-visible" do
+    %h3.text-lg.font-semibold.mb-4= t('bulk_edits.index.assign_title')
+
+    .grid.grid-cols-1.md:grid-cols-3.gap-4
+      .flex.flex-col
+        %label.text-sm.font-medium.text-gray-700.mb-1= t('bulk_edits.index.field_label')
+        = form.select :field, grouped_options_for_select(bulk_edit_field_groups.map { |group, opts| [group, opts.map { |label, value, _attrs| [label, value] }] }), {include_blank: t('bulk_edits.index.choose_field')}, class: 'px-3 py-2 border border-gray-300 rounded-md text-sm', data: {bulk_edit_form_target: "fieldSelect", action: "change->bulk-edit-form#fieldChanged"}
+
+      .flex.flex-col{data: {bulk_edit_form_target: "operationWrapper"}, style: "display: none"}
+        %label.text-sm.font-medium.text-gray-700.mb-1= t('bulk_edits.index.operation')
+        = form.select :operation, [[t('bulk_edits.index.op_add'), "add"], [t('bulk_edits.index.op_remove'), "remove"]], {}, class: 'px-3 py-2 border border-gray-300 rounded-md text-sm', data: {bulk_edit_form_target: "operationSelect", action: "change->bulk-edit-form#operationChanged"}
+
+      - BulkEdit::HABTM_FIELDS.each do |fld|
+        = render "value_input_habtm", field: fld
+      - BulkEdit::BELONGS_TO_FIELDS.each do |fld|
+        = render "value_input_belongs_to", field: fld
+      - BulkEdit::BOOLEAN_FIELDS.each do |fld|
+        = render "value_input_boolean", field: fld
+
+    = hidden_field_tag :operation, "set", id: "operation-fallback", data: {bulk_edit_form_target: "operationFallback"}
+
+    .mt-4.flex.items-center.gap-4
+      = form.submit t('bulk_edits.index.apply'), class: 'button primary', disabled: true, data: {bulk_edit_form_target: "submitButton", bulk_select_target: "submitButton"}
+      %span.text-sm.text-gray-600{data: {bulk_edit_form_target: "previewText"}}

--- a/app/views/bulk_edits/_protocol_changes.html.haml
+++ b/app/views/bulk_edits/_protocol_changes.html.haml
@@ -1,0 +1,25 @@
+- strategy = bulk_edit.strategy
+%turbo-frame{id: "bulk_edit_details_#{bulk_edit.id}"}
+  %div
+    %table.w-full.text-xs
+      %thead
+        %tr.border-b
+          %th.px-2.py-1.text-left.font-semibold= Word.human_attribute_name(:name)
+          %th.px-2.py-1.text-left.font-semibold= t('bulk_edits.index.previous_value')
+          %th.px-2.py-1.text-left.font-semibold= t('bulk_edits.index.applied_value')
+          %th.px-2.py-1.text-right.font-semibold
+      %tbody
+        - bulk_edit.word_changes.order(:id).each do |change|
+          %tr.border-b.border-gray-100{class: (change.reverted? ? "opacity-50" : "")}
+            %td.px-2.py-1
+              - if change.word
+                = link_to change.word.name, change.word, class: 'text-blue-600 hover:text-blue-900'
+              - else
+                %span.text-gray-400= t('bulk_edits.index.deleted_word')
+            %td.px-2.py-1.text-gray-700= strategy.display_value(change.previous_value)
+            %td.px-2.py-1.text-gray-700= strategy.display_value(change.applied_value)
+            %td.px-2.py-1.text-right
+              - if !change.reverted? && bulk_edit.undoable_by?(current_user)
+                = button_to t('bulk_edits.index.undo_word'), undo_bulk_edit_change_path(bulk_edit_id: bulk_edit.id, id: change.id), method: :post, class: 'button button-xs danger', data: {turbo_confirm: t('bulk_edits.index.undo_word_confirm')}
+              - elsif change.reverted?
+                %span.text-xs.text-gray-400= t('bulk_edits.index.reverted_at', time: l(change.reverted_at, format: :short))

--- a/app/views/bulk_edits/_protocol_table.html.haml
+++ b/app/views/bulk_edits/_protocol_table.html.haml
@@ -1,0 +1,43 @@
+= box do
+  - if @bulk_edits.any?
+    .overflow-x-auto
+      %table.w-full.text-sm
+        %thead
+          %tr.border-b.border-gray-300
+            %th.px-4.py-3.text-left.font-semibold.w-10
+            %th.px-4.py-3.text-left.font-semibold= t('bulk_edits.index.log_date')
+            %th.px-4.py-3.text-left.font-semibold= t('bulk_edits.index.log_user')
+            %th.px-4.py-3.text-left.font-semibold= t('bulk_edits.index.log_operation')
+            %th.px-4.py-3.text-left.font-semibold= t('bulk_edits.index.log_field')
+            %th.px-4.py-3.text-left.font-semibold= t('bulk_edits.index.log_values')
+            %th.px-4.py-3.text-left.font-semibold= t('bulk_edits.index.log_count')
+            %th.px-4.py-3.text-left.font-semibold= t('bulk_edits.index.log_query')
+            %th.px-4.py-3.text-right.font-semibold= t('bulk_edits.index.log_actions')
+        %tbody
+          - @bulk_edits.each do |edit|
+            %tr.border-b.border-gray-100.hover:bg-gray-50{class: (edit.undone? ? "opacity-50" : ""), data: {controller: "bulk-protocol"}}
+              %td.px-4.py-3
+                %button.text-gray-400.hover:text-gray-700{type: "button", data: {action: "click->bulk-protocol#toggle", url: details_bulk_edit_path(edit), frame_id: "bulk_edit_details_#{edit.id}"}, "aria-label": t('bulk_edits.index.toggle_details')}
+                  = heroicon('chevron-right', options: {class: 'w-4 h-4', data: {bulk_protocol_target: "chevron"}})
+              %td.px-4.py-3.text-sm.text-gray-500= l(edit.created_at, format: :short)
+              %td.px-4.py-3= edit.user.to_s
+              %td.px-4.py-3
+                %span.text-xs.px-2.py-1.rounded{class: operation_badge_class(edit.operation)}= t("bulk_edits.operations.#{edit.operation}")
+              %td.px-4.py-3= edit.field_label
+              %td.px-4.py-3.text-xs= edit.display_intent
+              %td.px-4.py-3= edit.affected_count
+              %td.px-4.py-3.text-xs.text-gray-500= edit.search_query
+              %td.px-4.py-3.text-right
+                - if edit.undoable_by?(current_user)
+                  = button_to t('bulk_edits.index.undo'), undo_bulk_edit_path(edit), method: :post, class: 'button button-sm danger', data: {turbo_confirm: t('bulk_edits.index.undo_confirm')}
+                - elsif edit.undone?
+                  %span.text-xs.text-gray-400= t('bulk_edits.index.undone_at', time: l(edit.undone_at, format: :short))
+            %tr.bg-gray-50{data: {bulk_protocol_target: "detailsRow"}, style: "display: none"}
+              %td.px-4.py-3{colspan: 9}
+                %turbo-frame{id: "bulk_edit_details_#{edit.id}"}
+                  .text-gray-500.text-sm= t('bulk_edits.index.loading')
+
+    .mt-4
+      = paginate @bulk_edits, param_name: :log_page
+  - else
+    %p.text-center.text-gray-600= t('bulk_edits.index.no_log_entries')

--- a/app/views/bulk_edits/_search_form.html.haml
+++ b/app/views/bulk_edits/_search_form.html.haml
@@ -1,0 +1,31 @@
+= box do
+  = form_with url: bulk_edits_path, method: :get, local: true, class: 'space-y-4' do |f|
+    .grid.grid-cols-1.md:grid-cols-5.gap-4
+      .flex.flex-col.md:col-span-2
+        = f.label :q, t('bulk_edits.index.search_label'), class: 'text-sm font-medium text-gray-700 mb-1'
+        = f.text_field :q, value: @search.q, placeholder: t('bulk_edits.index.search_placeholder'), class: 'px-3 py-2 border border-gray-300 rounded-md text-sm'
+      .flex.flex-col
+        = f.label :search_field, t('bulk_edits.index.search_field'), class: 'text-sm font-medium text-gray-700 mb-1'
+        = f.select :search_field, options_for_select([[t('bulk_edits.index.search_by_name'), 'name'], [t('bulk_edits.index.search_by_syllables'), 'syllables']], @search.search_field), {}, class: 'px-3 py-2 border border-gray-300 rounded-md text-sm'
+      .flex.flex-col
+        = f.label :word_type, t('bulk_edits.index.word_type'), class: 'text-sm font-medium text-gray-700 mb-1'
+        = f.select :word_type, options_for_select([[Noun.model_name.human, 'Noun'], [Verb.model_name.human, 'Verb'], [Adjective.model_name.human, 'Adjective'], [FunctionWord.model_name.human, 'FunctionWord']], @search.word_type), {include_blank: t('bulk_edits.index.all_types')}, class: 'px-3 py-2 border border-gray-300 rounded-md text-sm'
+      .flex.flex-col
+        = f.label :per_page, t('bulk_edits.index.per_page'), class: 'text-sm font-medium text-gray-700 mb-1'
+        = f.select :per_page, options_for_select([[50, 50], [100, 100], [t('bulk_edits.index.show_all'), 0]], @search.per_page), {}, class: 'px-3 py-2 border border-gray-300 rounded-md text-sm'
+
+    .grid.grid-cols-1.md:grid-cols-2.gap-4
+      .flex.flex-col
+        = f.label :missing_field, t('bulk_edits.index.missing_field'), class: 'text-sm font-medium text-gray-700 mb-1'
+        = f.select :missing_field, options_for_select(BulkEdit::ALL_FIELDS.map { |fld| [BulkEdit::FieldStrategy.for(fld).label, fld] }, @search.missing_field), {include_blank: t('bulk_edits.index.all_words')}, class: 'px-3 py-2 border border-gray-300 rounded-md text-sm'
+
+    .flex.gap-3.items-center
+      = f.submit t('bulk_edits.index.search_button'), class: 'button button-sm primary !mt-0'
+      - if @search.queried?
+        = link_to t('bulk_edits.index.clear'), bulk_edits_path, class: 'button button-sm !mt-0'
+
+    .text-xs.text-gray-500.italic= t('bulk_edits.index.wildcard_help')
+
+  - if @search.queried? && @words_total_count
+    .mt-2.text-sm.text-gray-700
+      %strong= t('bulk_edits.index.found', count: @words_total_count)

--- a/app/views/bulk_edits/_value_input_belongs_to.html.haml
+++ b/app/views/bulk_edits/_value_input_belongs_to.html.haml
@@ -1,0 +1,4 @@
+- model = field.delete_suffix("_id").classify.constantize
+.flex.flex-col{data: {bulk_edit_form_target: "valueInput", field: field, field_type: "belongs_to"}, style: "display: none"}
+  %label.text-sm.font-medium.text-gray-700.mb-1= Word.human_attribute_name(field.delete_suffix("_id"))
+  = select_tag "value", options_from_collection_for_select(model.order(:name), :id, :name), include_blank: t('bulk_edits.values.none'), class: 'px-3 py-2 border border-gray-300 rounded-md text-sm', data: {action: "change->bulk-edit-form#valueChanged"}

--- a/app/views/bulk_edits/_value_input_boolean.html.haml
+++ b/app/views/bulk_edits/_value_input_boolean.html.haml
@@ -1,0 +1,13 @@
+.flex.flex-col{data: {bulk_edit_form_target: "valueInput", field: field, field_type: "boolean"}, style: "display: none"}
+  %fieldset
+    %legend.text-sm.font-medium.text-gray-700.mb-1= Word.human_attribute_name(field)
+    .flex.gap-4.items-center
+      %label.flex.items-center.gap-1.cursor-pointer
+        = radio_button_tag "value", "", true, data: {action: "change->bulk-edit-form#valueChanged", field_owner: field}
+        %span.text-sm= t('bulk_edits.values.none')
+      %label.flex.items-center.gap-1.cursor-pointer
+        = radio_button_tag "value", "true", false, data: {action: "change->bulk-edit-form#valueChanged", field_owner: field}
+        %span.text-sm= t('simple_form.yes')
+      %label.flex.items-center.gap-1.cursor-pointer
+        = radio_button_tag "value", "false", false, data: {action: "change->bulk-edit-form#valueChanged", field_owner: field}
+        %span.text-sm= t('simple_form.no')

--- a/app/views/bulk_edits/_value_input_habtm.html.haml
+++ b/app/views/bulk_edits/_value_input_habtm.html.haml
@@ -1,0 +1,4 @@
+- model = field.classify.constantize
+.flex.flex-col{data: {bulk_edit_form_target: "valueInput", field: field, field_type: "habtm"}, style: "display: none"}
+  %label.text-sm.font-medium.text-gray-700.mb-1= model.model_name.human(count: 2)
+  = select_tag "value[]", options_from_collection_for_select(model.order(:name), :id, :name), multiple: true, data: {controller: "select", action: "change->bulk-edit-form#valueChanged"}, class: 'w-full'

--- a/app/views/bulk_edits/_words_table.html.haml
+++ b/app/views/bulk_edits/_words_table.html.haml
@@ -1,0 +1,34 @@
+.mt-6
+  = box padding: false do
+    .px-4.pt-4.pb-2.flex.flex-wrap.items-center.gap-4
+      %label.flex.items-center.gap-2.cursor-pointer
+        = check_box_tag "page_select_all", "1", false, data: {bulk_select_target: "pageSelectAll", action: "change->bulk-select#togglePage"}
+        %span.text-sm.font-medium= t('bulk_edits.index.select_page')
+      %button.text-sm.text-blue-600.hover:underline{type: "button", data: {bulk_select_target: "allMatchesButton", action: "click->bulk-select#toggleAllMatches"}}
+        = t('bulk_edits.index.select_all_matches', count: total)
+      %span.text-sm.text-gray-500.ml-auto{data: {bulk_select_target: "count"}}
+
+    .overflow-x-auto
+      %table.w-full.text-sm
+        %thead
+          %tr.border-b.border-gray-300
+            %th.px-4.py-3.text-left.w-10
+            %th.px-4.py-3.text-left.font-semibold= Word.human_attribute_name(:name)
+            %th.px-4.py-3.text-left.font-semibold= t('bulk_edits.index.word_type')
+            %th.px-4.py-3.text-left.font-semibold{data: {bulk_edit_form_target: "dynamicColumnHeader"}}= t('bulk_edits.index.current_value')
+        %tbody
+          - words.each do |word|
+            %tr.border-b.border-gray-100.hover:bg-gray-50{data: word_row_data(word)}
+              %td.px-4.py-3
+                -# Die Checkbox ist reines UI: kein name → sie wird beim Submit nicht serialisiert.
+                -# Die tatsächlichen IDs landen als Hidden-Inputs aus sessionStorage (siehe bulk_select_controller#syncHiddenIds).
+                %input{type: "checkbox", data: {bulk_select_target: "checkbox", word_id: word.id, action: "change->bulk-select#toggleCheckbox"}}
+              %td.px-4.py-3
+                = link_to word.name, word, class: 'text-blue-600 hover:text-blue-900 font-medium'
+              %td.px-4.py-3
+                %span.text-xs.bg-blue-100.text-blue-800.px-2.py-1.rounded= word.class.model_name.human
+              %td.px-4.py-3.text-xs.text-gray-700{data: {bulk_edit_form_target: "currentValueCell"}}
+
+    - if words.respond_to?(:total_pages) && words.total_pages > 1
+      .px-4.py-3.border-t.border-gray-100
+        = paginate words, params: {q: @search.q, search_field: @search.search_field, word_type: @search.word_type, per_page: @per_page, missing_field: @search.missing_field}

--- a/app/views/bulk_edits/index.html.haml
+++ b/app/views/bulk_edits/index.html.haml
@@ -1,0 +1,43 @@
+- set_meta_tags title: t('.page_title')
+
+= title_with_actions t('.title')
+
+%turbo-frame{id: "bulk_edits_content"}
+  -# Lokales Flash innerhalb des Frames — wird beim Frame-Swap aktualisiert.
+  -# Das Layout-Flash bleibt zwar leer (Layout wird nicht neu gerendert), aber dieses hier zeigt jedes Apply-/Undo-Ergebnis live.
+  - if flash[:notice].present? || flash[:alert].present?
+    .mb-4
+      - if flash[:notice].present?
+        .bg-green-50.border.border-green-200.text-green-800.rounded.px-4.py-3= flash[:notice]
+      - if flash[:alert].present?
+        .bg-amber-50.border.border-amber-200.text-amber-800.rounded.px-4.py-3= flash[:alert]
+
+  %div{data: {controller: "tabs"}, role: "tablist"}
+    .flex.flex-wrap.my-6.border-b
+      %button.px-4.py-2.cursor-pointer.font-bold.shadow.border.bg-white{type: "button", role: "tab", data: {tabs_target: "tab", action: "click->tabs#switch", tabs_panel: "massenbearbeitung"}}
+        = t('.tab_edit')
+      %button.px-4.py-2.cursor-pointer.hover:bg-white.flex.items-center.gap-2{type: "button", role: "tab", data: {tabs_target: "tab", action: "click->tabs#switch", tabs_panel: "protokoll"}}
+        = t('.tab_log')
+        - if @pending_count.to_i.positive?
+          %span.text-xs.bg-blue-100.text-blue-800.px-2.py-0.5.rounded-full= @pending_count
+
+    #massenbearbeitung{data: {tabs_target: "panel"}}
+      = render "search_form"
+
+      - if @search.queried? && (@words.blank? || @words_total_count.zero?)
+        .mt-6
+          = box do
+            %p.text-center.text-gray-600= t('.no_results')
+
+      - if @words.present?
+        = form_with url: bulk_edits_path, method: :post, data: {controller: "bulk-edit-form bulk-select", bulk_edit_form_confirm_threshold_value: 50, bulk_edit_form_confirm_template_value: t('.confirm_template', count: '%{count}'), bulk_edit_form_habtm_fields_value: BulkEdit::HABTM_FIELDS.to_json, bulk_edit_form_belongs_to_fields_value: BulkEdit::BELONGS_TO_FIELDS.to_json, bulk_edit_form_boolean_fields_value: BulkEdit::BOOLEAN_FIELDS.to_json, bulk_edit_form_i18n_preview: t('.preview_text', effective: '%{effective}', total: '%{total}', noop: '%{noop}'), bulk_edit_form_i18n_preview_all: t('.preview_all_matches', total: '%{total}'), bulk_edit_form_i18n_preview_all_unknown: t('.preview_all_matches_unknown'), bulk_select_count_template_value: t('.count_selected', count: '%{count}'), bulk_select_storage_key_value: "bulk_edit_selection", bulk_select_signature_value: @search.to_h.to_json, total_matches: @words_total_count} do |f|
+          - @search.to_h.each do |k, v|
+            = hidden_field_tag k, v
+          = hidden_field_tag :select_all, "", data: {bulk_select_target: "selectAllField"}
+
+          = render "assignment_panel", form: f
+          = render "words_table", form: f, words: @words, total: @words_total_count
+          = render "action_bar", form: f
+
+    #protokoll{data: {tabs_target: "panel"}, style: "display: none"}
+      = render "protocol_table"

--- a/app/views/pages/navigation.html.haml
+++ b/app/views/pages/navigation.html.haml
@@ -43,7 +43,7 @@
                   %p.text-sm.text-gray-600= t('navigation.browse_adjectives_help')
 
     / Content Management Section (only for logged in users)
-    - if user_signed_in? && (can?(:create, Noun) || can?(:create, Verb) || can?(:create, Adjective) || can?(:manage, :word_import) || can?(:manage, :word_images))
+    - if user_signed_in? && (can?(:create, Noun) || can?(:create, Verb) || can?(:create, Adjective) || can?(:manage, :word_import) || can?(:manage, :word_images) || can?(:manage, :bulk_edit))
       .mb-8
         %h3.text-2xl.font-bold.text-gray-900.mb-4.flex.items-center.gap-2
           = heroicon('pencil', options: {class: 'w-6 h-6 text-blue-600'})
@@ -89,6 +89,14 @@
                 %div
                   .font-semibold= t('navigation.word_images')
                   %p.text-sm.text-gray-600= t('navigation.word_images_help')
+
+          - if can?(:manage, :bulk_edit)
+            .nav-card
+              = link_to bulk_edits_path, class: 'nav-card-link' do
+                .nav-card-icon= heroicon('pencil-square', options: {class: 'w-5 h-5'})
+                %div
+                  .font-semibold= t('navigation.bulk_edits')
+                  %p.text-sm.text-gray-600= t('navigation.bulk_edits_help')
 
     / Learning & Practice Section (only for logged in users)
     - if user_signed_in? && [Theme, List].any? { |klass| can? :read, klass }

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -76,6 +76,12 @@ de:
       llm_service:
         one: LLM Service
         other: LLM Services
+      bulk_edit:
+        one: Massenbearbeitung
+        other: Massenbearbeitungen
+      bulk_edit_change:
+        one: Wortänderung
+        other: Wortänderungen
 
     attributes:
       user:
@@ -288,8 +294,37 @@ de:
         endpoint: URL
         api_key: API Key
         model: LLM Modellname
+      bulk_edit:
+        operation: Operation
+        field: Feld
+        intent_value: Wert
+        search_query: Suchabfrage
+        missing_field: Filter "ohne Wert in"
+        affected_count: Anzahl betroffene Wörter
+        undone_at: Rückgängig gemacht am
+
+    errors:
+      models:
+        bulk_edit:
+          attributes:
+            operation:
+              invalid_for_field: ist für das gewählte Feld nicht zulässig
 
   activemodel:
     attributes:
       llm_enrichment:
         list_id: Wortliste
+      forms/bulk_edit_form:
+        field: Feld
+        operation: Operation
+        value: Wert
+    errors:
+      models:
+        forms/bulk_edit_form:
+          no_words_selected: Bitte wähle mindestens ein Wort aus.
+          too_many_words: "Bitte verfeinere deinen Filter — die Massenbearbeitung ist auf %{max} Wörter pro Vorgang begrenzt."
+          attributes:
+            operation:
+              invalid_for_field: ist für das gewählte Feld nicht zulässig
+            value:
+              blank: muss gesetzt werden.

--- a/config/locales/navigation.de.yml
+++ b/config/locales/navigation.de.yml
@@ -41,6 +41,8 @@ de:
     create_adjective_help: "Fügen Sie neue Adjektive zur Datenbank hinzu"
     word_imports_help: "Importieren Sie Wörter in Großmengen aus Dateien"
     word_images_help: "Verwalten Sie Bilder für Wörter und weisen Sie sie zu"
+    bulk_edits: Massenbearbeitung
+    bulk_edits_help: "Mehrere Wörter gleichzeitig bearbeiten"
 
     # Help texts for Learning
     themes_help: "Erstellen und verwalten Sie benutzerdefinierte Lernthemen"

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -601,3 +601,86 @@ de:
       correct: Richtig
       back_to_list: "← Zurück zur Übersicht"
 
+  bulk_edits:
+    index:
+      page_title: Massenbearbeitung
+      title: Massenbearbeitung
+      tab_edit: Massenbearbeitung
+      tab_log: Protokoll
+      search_label: Wörter suchen
+      search_placeholder: "z.B. ^Haus*, *ung$, H?nd, Zel-le"
+      search_button: Suchen
+      clear: Filter zurücksetzen
+      wildcard_help: "Platzhalter: * = beliebig viele Zeichen, ? = ein Zeichen. Anker: ^ = Wortanfang, $ = Wortende. Beispiele: ^Haus* (beginnt mit Haus), *ung$ (endet auf ung). Bei Silbensuche: Zel-le, *-tion"
+      search_field: Suche in
+      search_by_name: Wortname
+      search_by_syllables: Silben
+      word_type: Wortart
+      all_types: Alle Wortarten
+      per_page: Pro Seite
+      show_all: Alle
+      missing_field: Nur Wörter ohne Wert in
+      all_words: Alle Wörter (kein Filter)
+      no_results: Keine Wörter gefunden.
+      found:
+        one: "%{count} Wort gefunden"
+        other: "%{count} Wörter gefunden"
+      count_selected:
+        one: "%{count} ausgewählt"
+        other: "%{count} ausgewählt"
+      select_page: Alle auf dieser Seite
+      select_all_matches:
+        one: "Alle %{count} Treffer auswählen"
+        other: "Alle %{count} Treffer auswählen"
+      clear_selection: Auswahl zurücksetzen
+      assign_title: Felder zuweisen
+      field_label: Feld
+      choose_field: Bitte wählen...
+      operation: Operation
+      op_add: Hinzufügen
+      op_remove: Entfernen
+      apply: Auf ausgewählte Wörter anwenden
+      current_value: Aktueller Wert
+      preview_text: "Wirkt sich auf %{effective} von %{total} Wörtern aus (%{noop} unverändert)"
+      preview_all_matches: "Wirkt sich auf alle %{total} Treffer aus"
+      preview_all_matches_unknown: Wirkt sich auf alle Treffer aus
+      confirm_template: "Das wirkt sich auf %{count} Wörter aus. Wirklich fortfahren?"
+      log_date: Datum
+      log_user: "Benutzer*in"
+      log_operation: Operation
+      log_field: Feld
+      log_values: Werte
+      log_count: Anzahl
+      log_query: Suchabfrage
+      log_actions: Aktionen
+      undo: Rückgängig
+      undo_confirm: Soll diese Operation wirklich rückgängig gemacht werden?
+      undone_at: "Rückgängig am %{time}"
+      undo_word: Pro Wort rückgängig
+      undo_word_confirm: Diese eine Wortänderung rückgängig machen?
+      reverted_at: "Pro Wort rückgängig am %{time}"
+      toggle_details: Details ein-/ausklappen
+      previous_value: Vorher
+      applied_value: Nachher
+      deleted_word: "(gelöschtes Wort)"
+      loading: "Lädt…"
+      no_log_entries: Noch keine Massenbearbeitungen durchgeführt.
+    field_groups:
+      habtm: Sammelfelder
+      belongs_to: Wortbildung
+      boolean: Eigenschaften
+    values:
+      none: "—"
+    operations:
+      add: Hinzufügen
+      remove: Entfernen
+      set: Setzen
+    create:
+      success:
+        one: "%{count} Wort wurde aktualisiert."
+        other: "%{count} Wörter wurden aktualisiert."
+      no_changes: Keine Wörter geändert (alle hatten den Wert bereits bzw. nicht).
+    undo:
+      success: Die Operation wurde erfolgreich rückgängig gemacht.
+      already_undone: Diese Operation wurde bereits rückgängig gemacht.
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,6 +123,15 @@ Rails.application.routes.draw do
     end
     resources :word_imports, only: %i[new create]
     resources :word_images, only: :index
+    resources :bulk_edits, only: %i[index create] do
+      member do
+        post :undo
+        get :details
+      end
+      resources :changes, only: [], controller: "bulk_edit_changes" do
+        member { post :undo }
+      end
+    end
 
     # User's own routes
     resource :profile, only: %i[show edit update] do

--- a/db/migrate/20260511151933_create_bulk_edits_and_changes.rb
+++ b/db/migrate/20260511151933_create_bulk_edits_and_changes.rb
@@ -1,0 +1,30 @@
+class CreateBulkEditsAndChanges < ActiveRecord::Migration[7.2]
+  def change
+    create_table :bulk_edits do |t|
+      t.references :user, null: false, foreign_key: {on_delete: :restrict}
+      t.string :operation, null: false
+      t.string :field, null: false
+      t.jsonb :intent_value, null: false
+      t.string :search_query
+      t.string :missing_field
+      t.integer :affected_count, null: false, default: 0
+      t.datetime :undone_at
+      t.timestamps
+    end
+
+    add_index :bulk_edits, [:user_id, :created_at]
+    add_index :bulk_edits, :undone_at
+
+    create_table :bulk_edit_changes do |t|
+      t.references :bulk_edit, null: false, foreign_key: true
+      t.references :word, foreign_key: {on_delete: :nullify}
+      t.jsonb :previous_value, null: false
+      t.jsonb :applied_value, null: false
+      t.datetime :reverted_at
+      t.timestamps
+    end
+
+    add_index :bulk_edit_changes, [:bulk_edit_id, :word_id], unique: true
+    add_index :bulk_edit_changes, :reverted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_191630) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_11_151933) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -43,6 +43,36 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_191630) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "bulk_edit_changes", force: :cascade do |t|
+    t.jsonb "applied_value", null: false
+    t.bigint "bulk_edit_id", null: false
+    t.datetime "created_at", null: false
+    t.jsonb "previous_value", null: false
+    t.datetime "reverted_at"
+    t.datetime "updated_at", null: false
+    t.bigint "word_id"
+    t.index ["bulk_edit_id", "word_id"], name: "index_bulk_edit_changes_on_bulk_edit_id_and_word_id", unique: true
+    t.index ["bulk_edit_id"], name: "index_bulk_edit_changes_on_bulk_edit_id"
+    t.index ["reverted_at"], name: "index_bulk_edit_changes_on_reverted_at"
+    t.index ["word_id"], name: "index_bulk_edit_changes_on_word_id"
+  end
+
+  create_table "bulk_edits", force: :cascade do |t|
+    t.integer "affected_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.string "field", null: false
+    t.jsonb "intent_value", null: false
+    t.string "missing_field"
+    t.string "operation", null: false
+    t.string "search_query"
+    t.datetime "undone_at"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["undone_at"], name: "index_bulk_edits_on_undone_at"
+    t.index ["user_id", "created_at"], name: "index_bulk_edits_on_user_id_and_created_at"
+    t.index ["user_id"], name: "index_bulk_edits_on_user_id"
   end
 
   create_table "change_groups", force: :cascade do |t|
@@ -113,7 +143,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_191630) do
     t.index ["key"], name: "index_global_settings_on_key", unique: true
   end
 
-  create_table "good_job_batches", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_batches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "callback_priority"
     t.text "callback_queue_name"
     t.datetime "created_at", null: false
@@ -129,7 +159,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_191630) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "good_job_executions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_executions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "active_job_id", null: false
     t.datetime "created_at", null: false
     t.interval "duration"
@@ -147,14 +177,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_191630) do
     t.index ["process_id", "created_at"], name: "index_good_job_executions_on_process_id_and_created_at"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "lock_type", limit: 2
     t.jsonb "state"
     t.datetime "updated_at", null: false
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "key"
     t.datetime "updated_at", null: false
@@ -162,7 +192,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_191630) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "active_job_id"
     t.uuid "batch_callback_id"
     t.uuid "batch_id"
@@ -614,6 +644,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_191630) do
     t.string "consonant_vowel"
     t.datetime "created_at", null: false
     t.jsonb "example_sentences", default: [], null: false
+    t.boolean "example_sentences_verified", default: false, null: false
     t.boolean "foreign", default: false, null: false
     t.integer "function_type"
     t.bigint "genus_feminine_id"
@@ -622,6 +653,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_191630) do
     t.bigint "genus_neuter_id"
     t.bigint "hierarchy_id"
     t.bigint "hit_counter", default: 0, null: false
+    t.string "image_alt_text"
     t.string "imperative_plural"
     t.string "imperative_singular"
     t.boolean "irregular_comparison", default: false, null: false
@@ -657,8 +689,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_191630) do
     t.boolean "subjectless", default: false, null: false
     t.string "superlative", default: ""
     t.string "syllables", default: ""
+    t.boolean "syllables_verified", default: false, null: false
     t.string "type", null: false
     t.datetime "updated_at", null: false
+    t.string "wiktionary_syllables"
     t.boolean "with_tts", default: true, null: false
     t.string "written_syllables", default: ""
     t.index "lower((name)::text)", name: "idx_words_lower_name"
@@ -700,6 +734,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_191630) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "bulk_edit_changes", "bulk_edits"
+  add_foreign_key "bulk_edit_changes", "words", on_delete: :nullify
+  add_foreign_key "bulk_edits", "users", on_delete: :restrict
   add_foreign_key "change_groups", "change_groups", column: "successor_id"
   add_foreign_key "hierarchies", "hierarchies", column: "top_hierarchy_id"
   add_foreign_key "image_requests", "users"

--- a/test/controllers/bulk_edits_controller_test.rb
+++ b/test/controllers/bulk_edits_controller_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BulkEditsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = create(:admin)
+    @lecturer_a = create(:lecturer)
+    @lecturer_b = create(:lecturer)
+    @noun = create(:noun, name: "Haus")
+    @phenomenon = create(:phenomenon, name: "P")
+  end
+
+  test "POST /seite/bulk_edits without a field redirects with an alert" do
+    sign_in @admin
+    post bulk_edits_path, params: {selected_ids: [@noun.id]}
+    assert_response :redirect
+    assert response.location.start_with?(bulk_edits_url)
+  end
+
+  test "POST /seite/bulk_edits/:id/undo by a foreign Lecturer raises CanCan::AccessDenied" do
+    bulk_edit = BulkEditService.new(user: @lecturer_a).execute(
+      word_ids: [@noun.id], field: "phenomenons", operation: "add", value: {"ids" => [@phenomenon.id]}
+    )
+    sign_in @lecturer_b
+
+    assert_raises(CanCan::AccessDenied) { post undo_bulk_edit_path(bulk_edit) }
+    assert_nil bulk_edit.reload.undone_at
+  end
+
+  test "POST /seite/bulk_edits/:bulk_edit_id/changes/:id/undo by a foreign Lecturer raises CanCan::AccessDenied" do
+    bulk_edit = BulkEditService.new(user: @lecturer_a).execute(
+      word_ids: [@noun.id], field: "phenomenons", operation: "add", value: {"ids" => [@phenomenon.id]}
+    )
+    change = bulk_edit.word_changes.first
+    sign_in @lecturer_b
+
+    assert_raises(CanCan::AccessDenied) do
+      post undo_bulk_edit_change_path(bulk_edit_id: bulk_edit.id, id: change.id)
+    end
+    assert_nil change.reload.reverted_at
+  end
+
+  test "an Admin can undo any entry" do
+    bulk_edit = BulkEditService.new(user: @lecturer_a).execute(
+      word_ids: [@noun.id], field: "phenomenons", operation: "add", value: {"ids" => [@phenomenon.id]}
+    )
+    sign_in @admin
+
+    post undo_bulk_edit_path(bulk_edit)
+    assert_redirected_to bulk_edits_path(anchor: "protokoll")
+    assert bulk_edit.reload.undone_at.present?
+  end
+end

--- a/test/factories/bulk_edits.rb
+++ b/test/factories/bulk_edits.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :bulk_edit do
+    association :user, factory: :admin
+    operation { "add" }
+    field { "phenomenons" }
+    intent_value { {"ids" => []} }
+    affected_count { 0 }
+  end
+
+  factory :bulk_edit_change do
+    bulk_edit
+    word { association :noun }
+    previous_value { {"ids" => []} }
+    applied_value { {"ids" => []} }
+  end
+end

--- a/test/form_objects/forms/bulk_edit_form_test.rb
+++ b/test/form_objects/forms/bulk_edit_form_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Forms::BulkEditFormTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:admin)
+    @noun = create(:noun, name: "Haus")
+    @phenomenon = create(:phenomenon, name: "P")
+  end
+
+  test "requires a field" do
+    form = Forms::BulkEditForm.new({selected_ids: [@noun.id]}, user: @user)
+    refute form.valid?
+    assert form.errors[:field].any?
+  end
+
+  test "rejects an operation that doesn't fit the field type" do
+    form = Forms::BulkEditForm.new(
+      {selected_ids: [@noun.id], field: "prototype", operation: "add", value: "true"},
+      user: @user
+    )
+    refute form.valid?
+    assert form.errors[:operation].any?
+  end
+
+  test "rejects a blank boolean value (3-state 'unset' is not applyable)" do
+    form = Forms::BulkEditForm.new(
+      {selected_ids: [@noun.id], field: "foreign", operation: "set", value: ""},
+      user: @user
+    )
+    refute form.valid?
+    assert form.errors[:value].any?
+  end
+
+  test "rejects an empty word selection" do
+    form = Forms::BulkEditForm.new(
+      {field: "phenomenons", operation: "add", value: [@phenomenon.id.to_s]},
+      user: @user
+    )
+    refute form.valid?
+    assert form.errors[:base].any?
+  end
+
+  test "rejects more than MAX_WORDS_PER_OPERATION word ids" do
+    BulkEdit.const_set(:MAX_WORDS_PER_OPERATION, 2)
+    a, b, c = create_list(:noun, 3)
+    form = Forms::BulkEditForm.new(
+      {selected_ids: [a.id, b.id, c.id], field: "phenomenons", operation: "add", value: [@phenomenon.id.to_s]},
+      user: @user
+    )
+    refute form.valid?
+    assert_includes form.errors[:base].join, "2"
+  ensure
+    BulkEdit.const_set(:MAX_WORDS_PER_OPERATION, 5_000)
+  end
+
+  test "select_all=1 resolves word_ids from the search instead of explicit selection" do
+    second = create(:noun, name: "Hand")
+    form = Forms::BulkEditForm.new(
+      {select_all: "1", q: "*", field: "phenomenons", operation: "add", value: [@phenomenon.id.to_s]},
+      user: @user
+    )
+    assert_includes form.word_ids_for_apply, @noun.id
+    assert_includes form.word_ids_for_apply, second.id
+  end
+
+  test "#to_service_args delegates value normalization to the strategy" do
+    form = Forms::BulkEditForm.new(
+      {selected_ids: [@noun.id], field: "phenomenons", operation: "add", value: [@phenomenon.id.to_s], q: "Haus*"},
+      user: @user
+    )
+    assert form.valid?, form.errors.full_messages.inspect
+
+    args = form.to_service_args
+    assert_equal "phenomenons", args[:field]
+    assert_equal({"ids" => [@phenomenon.id]}, args[:value])
+    assert_equal "Haus*", args[:search_query]
+  end
+end

--- a/test/form_objects/forms/bulk_edit_search_test.rb
+++ b/test/form_objects/forms/bulk_edit_search_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Forms::BulkEditSearchTest < ActiveSupport::TestCase
+  test "anchors the wildcard pattern with ^ at the start" do
+    haustier = create(:noun, name: "Haustier")
+    hausboot = create(:noun, name: "Hausboot")
+    create(:noun, name: "Schule")
+
+    names = Forms::BulkEditSearch.new(q: "^Haus*").results.pluck(:name)
+    assert_equal [hausboot.name, haustier.name].sort, names.sort
+  end
+
+  test "anchors the wildcard pattern with $ at the end" do
+    create(:noun, name: "Haus")
+    lehrung = create(:noun, name: "Lehrung")
+
+    names = Forms::BulkEditSearch.new(q: "*ung$").results.pluck(:name)
+    assert_equal [lehrung.name], names
+  end
+
+  test "matches exactly with ^...$" do
+    schule = create(:noun, name: "Schule")
+    create(:noun, name: "Schulen")
+
+    names = Forms::BulkEditSearch.new(q: "^Schule$").results.pluck(:name)
+    assert_equal [schule.name], names
+  end
+
+  test "filters by word_type when given" do
+    create(:noun, name: "Haus")
+    verb = create(:verb, name: "gehen")
+
+    results = Forms::BulkEditSearch.new(q: "*e*", word_type: "Verb").results.to_a
+    assert_includes results, verb
+  end
+
+  test "falls back to the name field when an unknown search_field is given" do
+    create(:noun, name: "Haus")
+    assert_nothing_raised { Forms::BulkEditSearch.new(q: "Haus", search_field: "secret").results.load }
+  end
+
+  test "missing_field filter returns only words without that HABTM association" do
+    with_p = create(:noun, name: "Mit")
+    with_p.phenomenons << create(:phenomenon, name: "P")
+    without_p = create(:noun, name: "Ohne")
+
+    results = Forms::BulkEditSearch.new(missing_field: "phenomenons").results.to_a
+    assert_includes results, without_p
+    refute_includes results, with_p
+  end
+
+  test "ignores an unknown missing_field" do
+    assert_nothing_raised { Forms::BulkEditSearch.new(missing_field: "junk").results.load }
+  end
+
+  test "#queried? returns true when q or missing_field is set" do
+    assert Forms::BulkEditSearch.new(q: "x").queried?
+    assert Forms::BulkEditSearch.new(missing_field: "phenomenons").queried?
+    refute Forms::BulkEditSearch.new({}).queried?
+  end
+end

--- a/test/models/bulk_edit/field_strategy/belongs_to_test.rb
+++ b/test/models/bulk_edit/field_strategy/belongs_to_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BulkEdit::FieldStrategy::BelongsToTest < ActiveSupport::TestCase
+  setup do
+    @strategy = BulkEdit::FieldStrategy::BelongsTo.new("hierarchy_id")
+    @word = create(:noun)
+    @h1 = create(:hierarchy, name: "H1")
+  end
+
+  test "#normalize_input converts a string id to an integer" do
+    assert_equal({"id" => 42}, @strategy.normalize_input("42"))
+    assert_equal({"id" => 42}, @strategy.normalize_input(["42"]))
+  end
+
+  test "#normalize_input returns nil id for empty input (set-to-NULL is allowed)" do
+    assert_equal({"id" => nil}, @strategy.normalize_input(""))
+    assert_equal({"id" => nil}, @strategy.normalize_input([""]))
+    assert_equal({"id" => nil}, @strategy.normalize_input(nil))
+  end
+
+  test "#apply updates the foreign key and records the previous value" do
+    @word.update!(hierarchy_id: nil)
+    result = @strategy.apply(@word, {"id" => @h1.id}, "set")
+
+    assert_equal @h1.id, @word.reload.hierarchy_id
+    assert_equal({previous: {"id" => nil}, applied: {"id" => @h1.id}}, result)
+  end
+
+  test "#apply sets the foreign key to NULL when value is nil" do
+    @word.update!(hierarchy_id: @h1.id)
+    result = @strategy.apply(@word, {"id" => nil}, "set")
+
+    assert_nil @word.reload.hierarchy_id
+    assert_equal({previous: {"id" => @h1.id}, applied: {"id" => nil}}, result)
+  end
+
+  test "#apply is a no-op when old value equals new value" do
+    @word.update!(hierarchy_id: @h1.id)
+    assert_nil @strategy.apply(@word, {"id" => @h1.id}, "set")
+  end
+
+  test "#revert restores the previous foreign key" do
+    @word.update!(hierarchy_id: @h1.id)
+    change = BulkEditChange.new(previous_value: {"id" => nil}, applied_value: {"id" => @h1.id})
+    @strategy.revert(@word, change)
+    assert_nil @word.reload.hierarchy_id
+  end
+
+  test "#display_current uses the preloaded association" do
+    @word.update!(hierarchy_id: @h1.id)
+    assert_equal "H1", @strategy.display_current(@word.reload)
+  end
+
+  test "#display_current returns the locale 'none' placeholder when the value is nil" do
+    assert_equal I18n.t("bulk_edits.values.none"), @strategy.display_current(@word)
+  end
+
+  test "#display_value resolves the value hash to the associated record name" do
+    assert_equal "H1", @strategy.display_value({"id" => @h1.id})
+    assert_equal I18n.t("bulk_edits.values.none"), @strategy.display_value({"id" => nil})
+  end
+
+  test "#missing_scope returns words with a nil foreign key" do
+    with_h = create(:noun, hierarchy: @h1)
+    without_h = create(:noun, hierarchy: nil)
+    scope = @strategy.missing_scope(Word.all)
+
+    assert_includes scope, without_h
+    refute_includes scope, with_h
+  end
+end

--- a/test/models/bulk_edit/field_strategy/boolean_test.rb
+++ b/test/models/bulk_edit/field_strategy/boolean_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BulkEdit::FieldStrategy::BooleanTest < ActiveSupport::TestCase
+  setup do
+    @strategy = BulkEdit::FieldStrategy::Boolean.new("foreign")
+    @word = create(:noun)
+  end
+
+  test "#normalize_input casts strings to booleans" do
+    assert_equal({"value" => true}, @strategy.normalize_input("true"))
+    assert_equal({"value" => false}, @strategy.normalize_input("false"))
+    assert_equal({"value" => true}, @strategy.normalize_input(["true"]))
+  end
+
+  test "#normalize_input returns nil for the 3-state 'unset' option" do
+    assert_nil @strategy.normalize_input("")
+    assert_nil @strategy.normalize_input([""])
+    assert_nil @strategy.normalize_input(nil)
+  end
+
+  test "#apply sets the boolean to true and records the previous value" do
+    @word.update!(foreign: false)
+    result = @strategy.apply(@word, {"value" => true}, "set")
+
+    assert @word.reload.foreign
+    assert_equal({previous: {"value" => false}, applied: {"value" => true}}, result)
+  end
+
+  test "#apply sets the boolean to false (from true)" do
+    @word.update!(foreign: true)
+    result = @strategy.apply(@word, {"value" => false}, "set")
+
+    refute @word.reload.foreign
+    assert_equal({previous: {"value" => true}, applied: {"value" => false}}, result)
+  end
+
+  test "#apply is a no-op when the value is unchanged" do
+    @word.update!(foreign: true)
+    assert_nil @strategy.apply(@word, {"value" => true}, "set")
+  end
+
+  test "#revert restores the previous boolean value" do
+    @word.update!(foreign: false)
+    change = BulkEditChange.new(previous_value: {"value" => true}, applied_value: {"value" => false})
+    @strategy.revert(@word, change)
+    assert @word.reload.foreign
+  end
+
+  test "#display_current returns 'Ja' or 'Nein'" do
+    @word.update!(foreign: true)
+    assert_equal I18n.t("simple_form.yes"), @strategy.display_current(@word.reload)
+    @word.update!(foreign: false)
+    assert_equal I18n.t("simple_form.no"), @strategy.display_current(@word.reload)
+  end
+
+  test "#display_value formats a recorded nil value as 'none' (for legacy records)" do
+    assert_equal I18n.t("bulk_edits.values.none"), @strategy.display_value({"value" => nil})
+  end
+
+  test "#missing_scope returns words with the boolean unset or false" do
+    true_word = create(:noun, foreign: true)
+    false_word = create(:noun, foreign: false)
+    scope = @strategy.missing_scope(Word.all)
+
+    assert_includes scope, false_word
+    refute_includes scope, true_word
+  end
+end

--- a/test/models/bulk_edit/field_strategy/habtm_test.rb
+++ b/test/models/bulk_edit/field_strategy/habtm_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BulkEdit::FieldStrategy::HabtmTest < ActiveSupport::TestCase
+  setup do
+    @strategy = BulkEdit::FieldStrategy::Habtm.new("phenomenons")
+    @word = create(:noun)
+    @p1 = create(:phenomenon, name: "P1")
+    @p2 = create(:phenomenon, name: "P2")
+  end
+
+  test "#normalize_input returns an ids hash for arrays" do
+    assert_equal({"ids" => [@p1.id, @p2.id]}, @strategy.normalize_input([@p1.id, @p2.id]))
+  end
+
+  test "#normalize_input rejects zero and blank entries and deduplicates" do
+    assert_equal({"ids" => [@p1.id]}, @strategy.normalize_input([@p1.id, @p1.id, 0, ""]))
+  end
+
+  test "#normalize_input returns nil for empty input" do
+    assert_nil @strategy.normalize_input([])
+    assert_nil @strategy.normalize_input(nil)
+  end
+
+  test "#apply 'add' attaches missing ids and reports the delta" do
+    result = @strategy.apply(@word, {"ids" => [@p1.id]}, "add")
+    assert_equal [@p1], @word.reload.phenomenons.to_a
+    assert_equal({previous: {"ids" => []}, applied: {"ids" => [@p1.id]}}, result)
+  end
+
+  test "#apply 'add' is a no-op when the value is already present" do
+    @word.phenomenons << @p1
+    assert_nil @strategy.apply(@word, {"ids" => [@p1.id]}, "add")
+  end
+
+  test "#apply 'add' stores only the delta when value is partially present" do
+    @word.phenomenons << @p1
+    result = @strategy.apply(@word, {"ids" => [@p1.id, @p2.id]}, "add")
+    assert_equal [@p2.id], result[:applied]["ids"]
+  end
+
+  test "#apply 'remove' detaches the requested ids and reports the delta" do
+    @word.phenomenons << @p1
+    result = @strategy.apply(@word, {"ids" => [@p1.id]}, "remove")
+    assert_empty @word.reload.phenomenons.to_a
+    assert_equal({previous: {"ids" => [@p1.id]}, applied: {"ids" => []}}, result)
+  end
+
+  test "#apply 'remove' is a no-op when the value is not present" do
+    assert_nil @strategy.apply(@word, {"ids" => [@p1.id]}, "remove")
+  end
+
+  test "#revert reverses an add by removing the added ids" do
+    @word.phenomenons << @p1
+    change = build_change(applied: {"ids" => [@p1.id]}, previous: {"ids" => []})
+    @strategy.revert(@word, change)
+    assert_empty @word.reload.phenomenons.to_a
+  end
+
+  test "#revert reverses a remove by re-attaching the previous ids" do
+    change = build_change(applied: {"ids" => []}, previous: {"ids" => [@p1.id]})
+    @strategy.revert(@word, change)
+    assert_equal [@p1], @word.reload.phenomenons.to_a
+  end
+
+  test "#revert is idempotent when the value is already present" do
+    @word.phenomenons << @p1
+    change = build_change(applied: {"ids" => []}, previous: {"ids" => [@p1.id]})
+    assert_no_difference -> { @word.reload.phenomenons.count } do
+      @strategy.revert(@word, change)
+    end
+  end
+
+  test "#current_value returns the ids of the associated records" do
+    @word.phenomenons << [@p1, @p2]
+    assert_equal [@p1.id, @p2.id].sort, @strategy.current_value(@word.reload).sort
+  end
+
+  test "#display_current returns the locale 'none' placeholder when empty" do
+    assert_equal I18n.t("bulk_edits.values.none"), @strategy.display_current(@word)
+  end
+
+  test "#display_current joins associated names with commas" do
+    @word.phenomenons << @p1
+    assert_equal "P1", @strategy.display_current(@word.reload)
+  end
+
+  test "#missing_scope returns words without this HABTM association" do
+    with_p = create(:noun)
+    with_p.phenomenons << @p1
+    without_p = create(:noun)
+    scope = @strategy.missing_scope(Word.all)
+
+    assert_includes scope, without_p
+    refute_includes scope, with_p
+  end
+
+  private
+
+  def build_change(applied:, previous:)
+    BulkEditChange.new(applied_value: applied, previous_value: previous)
+  end
+end

--- a/test/models/bulk_edit_change_test.rb
+++ b/test/models/bulk_edit_change_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BulkEditChangeTest < ActiveSupport::TestCase
+  test "scopes split pending from reverted entries" do
+    pending = create(:bulk_edit_change, reverted_at: nil)
+    reverted = create(:bulk_edit_change, reverted_at: Time.current)
+
+    assert_equal [pending], BulkEditChange.pending.to_a
+    assert_equal [reverted], BulkEditChange.reverted.to_a
+  end
+
+  test "#reverted? reads from reverted_at" do
+    refute build(:bulk_edit_change, reverted_at: nil).reverted?
+    assert build(:bulk_edit_change, reverted_at: Time.current).reverted?
+  end
+end

--- a/test/models/bulk_edit_test.rb
+++ b/test/models/bulk_edit_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BulkEditTest < ActiveSupport::TestCase
+  test "rejects an unknown field" do
+    record = build(:bulk_edit, field: "nonsense")
+    refute record.valid?
+    assert record.errors[:field].any?
+  end
+
+  test "rejects an unknown operation" do
+    record = build(:bulk_edit, operation: "frobnicate")
+    refute record.valid?
+    assert record.errors[:operation].any?
+  end
+
+  test "rejects an operation that doesn't fit the field type" do
+    record = build(:bulk_edit, field: "prototype", operation: "add", intent_value: {"value" => true})
+    refute record.valid?
+    assert record.errors[:operation].any?
+  end
+
+  test "accepts add/remove for HABTM fields" do
+    record = build(:bulk_edit, field: "phenomenons", operation: "remove")
+    assert record.valid?, record.errors.full_messages.inspect
+  end
+
+  test "accepts set for belongs_to fields" do
+    record = build(:bulk_edit, field: "hierarchy_id", operation: "set", intent_value: {"id" => nil})
+    assert record.valid?, record.errors.full_messages.inspect
+  end
+
+  test "accepts set for boolean fields" do
+    record = build(:bulk_edit, field: "foreign", operation: "set", intent_value: {"value" => true})
+    assert record.valid?, record.errors.full_messages.inspect
+  end
+
+  test ".undoable_by returns all entries for an Admin" do
+    admin = create(:admin)
+    lecturer = create(:lecturer)
+    by_admin = create(:bulk_edit, user: admin)
+    by_lecturer = create(:bulk_edit, user: lecturer)
+
+    assert_equal [by_admin, by_lecturer].sort, BulkEdit.undoable_by(admin).order(:id).to_a
+  end
+
+  test ".undoable_by limits a Lecturer to their own entries" do
+    lecturer_a = create(:lecturer)
+    lecturer_b = create(:lecturer)
+    own = create(:bulk_edit, user: lecturer_a)
+    create(:bulk_edit, user: lecturer_b)
+
+    assert_equal [own], BulkEdit.undoable_by(lecturer_a).to_a
+  end
+
+  test "#undoable_by? returns false once the entry is undone" do
+    admin = create(:admin)
+    record = create(:bulk_edit, user: admin, undone_at: Time.current)
+    refute record.undoable_by?(admin)
+  end
+
+  test "#undoable_by? lets an Admin undo any entry" do
+    admin = create(:admin)
+    lecturer = create(:lecturer)
+    record = create(:bulk_edit, user: lecturer)
+    assert record.undoable_by?(admin)
+  end
+
+  test "#undoable_by? lets a Lecturer undo only their own entries" do
+    lecturer_a = create(:lecturer)
+    lecturer_b = create(:lecturer)
+    own = create(:bulk_edit, user: lecturer_a)
+
+    assert own.undoable_by?(lecturer_a)
+    refute own.undoable_by?(lecturer_b)
+  end
+
+  test "#strategy returns the matching strategy" do
+    record = build(:bulk_edit, field: "hierarchy_id", operation: "set", intent_value: {"id" => nil})
+    assert_kind_of BulkEdit::FieldStrategy::BelongsTo, record.strategy
+  end
+
+  test "#field_label and #display_intent delegate to the strategy" do
+    hierarchy = create(:hierarchy, name: "Säugetier")
+    record = build(:bulk_edit, field: "hierarchy_id", operation: "set", intent_value: {"id" => hierarchy.id})
+
+    assert_equal Word.human_attribute_name(:hierarchy), record.field_label
+    assert_equal "Säugetier", record.display_intent
+  end
+end

--- a/test/services/bulk_edit_service_test.rb
+++ b/test/services/bulk_edit_service_test.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BulkEditServiceTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:admin)
+    @service = BulkEditService.new(user: @user)
+    @noun1 = create(:noun, name: "Haus")
+    @noun2 = create(:noun, name: "Hof")
+    @p1 = create(:phenomenon, name: "P1")
+  end
+
+  test "#execute applies HABTM add and stores one change per affected word" do
+    bulk_edit = @service.execute(
+      word_ids: [@noun1.id, @noun2.id],
+      field: "phenomenons",
+      operation: "add",
+      value: {"ids" => [@p1.id]},
+      search_query: "H*"
+    )
+
+    assert_equal 2, bulk_edit.affected_count
+    assert_equal 2, bulk_edit.word_changes.count
+    assert_equal({"ids" => [@p1.id]}, bulk_edit.intent_value)
+    assert_includes @noun1.reload.phenomenons, @p1
+    assert_includes @noun2.reload.phenomenons, @p1
+  end
+
+  test "#execute creates no BulkEdit when nothing actually changes" do
+    @noun1.phenomenons << @p1
+    @noun2.phenomenons << @p1
+
+    assert_no_difference -> { BulkEdit.count } do
+      result = @service.execute(
+        word_ids: [@noun1.id, @noun2.id],
+        field: "phenomenons",
+        operation: "add",
+        value: {"ids" => [@p1.id]}
+      )
+      assert_nil result
+    end
+  end
+
+  test "#execute stores only the per-word delta, not the full requested set" do
+    @noun1.phenomenons << @p1
+    p2 = create(:phenomenon, name: "P2")
+
+    bulk_edit = @service.execute(
+      word_ids: [@noun1.id, @noun2.id],
+      field: "phenomenons",
+      operation: "add",
+      value: {"ids" => [@p1.id, p2.id]}
+    )
+
+    changes = bulk_edit.word_changes.index_by(&:word_id)
+    assert_equal [p2.id], changes[@noun1.id].applied_value["ids"]
+    assert_equal [@p1.id, p2.id].sort, changes[@noun2.id].applied_value["ids"].sort
+  end
+
+  test "#execute raises ArgumentError when operation doesn't fit the field" do
+    assert_raises(ArgumentError) do
+      @service.execute(
+        word_ids: [@noun1.id],
+        field: "prototype",
+        operation: "add",
+        value: {"value" => true}
+      )
+    end
+  end
+
+  test "#execute applies a belongs_to 'set' to the foreign key" do
+    hierarchy = create(:hierarchy, name: "Säugetier")
+    bulk_edit = @service.execute(
+      word_ids: [@noun1.id],
+      field: "hierarchy_id",
+      operation: "set",
+      value: {"id" => hierarchy.id}
+    )
+
+    assert_equal hierarchy.id, @noun1.reload.hierarchy_id
+    assert_equal({"id" => hierarchy.id}, bulk_edit.word_changes.first.applied_value)
+  end
+
+  test "#execute applies a boolean 'set' to false" do
+    @noun1.update!(foreign: true)
+    bulk_edit = @service.execute(
+      word_ids: [@noun1.id],
+      field: "foreign",
+      operation: "set",
+      value: {"value" => false}
+    )
+
+    refute @noun1.reload.foreign
+    assert_equal({"value" => false}, bulk_edit.word_changes.first.applied_value)
+  end
+
+  test "#undo reverts every pending change and marks the header as undone" do
+    bulk_edit = @service.execute(
+      word_ids: [@noun1.id, @noun2.id],
+      field: "phenomenons",
+      operation: "add",
+      value: {"ids" => [@p1.id]}
+    )
+    @service.undo(bulk_edit)
+
+    assert bulk_edit.reload.undone_at.present?
+    assert_empty @noun1.reload.phenomenons.to_a
+    assert_empty @noun2.reload.phenomenons.to_a
+    assert_empty bulk_edit.word_changes.pending.to_a
+  end
+
+  test "#undo raises AlreadyUndone on a second call" do
+    bulk_edit = @service.execute(
+      word_ids: [@noun1.id], field: "phenomenons", operation: "add", value: {"ids" => [@p1.id]}
+    )
+    @service.undo(bulk_edit)
+    assert_raises(BulkEditService::AlreadyUndone) { @service.undo(bulk_edit) }
+  end
+
+  test "#undo tolerates a word that was deleted between execute and undo" do
+    bulk_edit = @service.execute(
+      word_ids: [@noun1.id], field: "phenomenons", operation: "add", value: {"ids" => [@p1.id]}
+    )
+    @noun1.destroy
+
+    assert_nothing_raised { @service.undo(bulk_edit) }
+    assert bulk_edit.reload.undone_at.present?
+  end
+
+  test "#undo_change reverts a single change and leaves siblings pending" do
+    bulk_edit = @service.execute(
+      word_ids: [@noun1.id, @noun2.id], field: "phenomenons", operation: "add", value: {"ids" => [@p1.id]}
+    )
+    change = bulk_edit.word_changes.find_by(word: @noun1)
+    @service.undo_change(change)
+
+    assert change.reload.reverted_at.present?
+    assert_empty @noun1.reload.phenomenons.to_a
+    assert_includes @noun2.reload.phenomenons, @p1
+    assert_nil bulk_edit.reload.undone_at
+  end
+
+  test "#undo_change auto-completes the header when reverting the last pending change" do
+    bulk_edit = @service.execute(
+      word_ids: [@noun1.id], field: "phenomenons", operation: "add", value: {"ids" => [@p1.id]}
+    )
+    @service.undo_change(bulk_edit.word_changes.first)
+    assert bulk_edit.reload.undone_at.present?
+  end
+
+  test "#undo_change raises AlreadyReverted on a second call" do
+    bulk_edit = @service.execute(
+      word_ids: [@noun1.id], field: "phenomenons", operation: "add", value: {"ids" => [@p1.id]}
+    )
+    change = bulk_edit.word_changes.first
+    @service.undo_change(change)
+    assert_raises(BulkEditService::AlreadyReverted) { @service.undo_change(change.reload) }
+  end
+
+  test "#execute supports 'sources' as a HABTM field" do
+    source = create(:source, name: "Wiktionary")
+    bulk_edit = @service.execute(
+      word_ids: [@noun1.id], field: "sources", operation: "add", value: {"ids" => [source.id]}
+    )
+
+    assert_equal 1, bulk_edit.affected_count
+    assert_includes @noun1.reload.sources, source
+  end
+end

--- a/test/support/cuprite_helpers.rb
+++ b/test/support/cuprite_helpers.rb
@@ -25,6 +25,27 @@ module CupriteHelpers
     JS
   end
 
+  # Strip `form-submission` from a form's `data-controller` so its Stimulus
+  # controller stops firing a fetch on every input event. The search page
+  # auto-submits the filter form on each keystroke; combined with `fill_in`
+  # typing one character at a time, that yields overlapping fetches whose
+  # turbo_stream responses re-render frames (including #add_words_to_list)
+  # and detach elements the test is about to interact with. Disable the
+  # auto-submit, set fields, then click the apply button for a single
+  # deterministic form submission.
+  def disable_form_auto_submit
+    page.execute_script(<<~JS)
+      document.querySelectorAll('form[data-controller~="form-submission"]').forEach(form => {
+        const controllers = (form.dataset.controller || '').split(/\\s+/).filter(c => c !== 'form-submission');
+        if (controllers.length) {
+          form.dataset.controller = controllers.join(' ');
+        } else {
+          form.removeAttribute('data-controller');
+        }
+      });
+    JS
+  end
+
   # Run a Capybara interaction that can race a Turbo re-render. The
   # rescue list covers the four ways Cuprite signals "the DOM moved under
   # us mid-action" — ObsoleteNode (node detached), CoordinatesNotFound

--- a/test/system/bulk_edits_test.rb
+++ b/test/system/bulk_edits_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class BulkEditsTest < ApplicationSystemTestCase
+  test "admin finds words by wildcard search" do
+    admin = create(:admin)
+    create(:noun, name: "Haustier")
+    create(:noun, name: "Hausboot")
+    create(:noun, name: "Schule")
+
+    login_as admin
+    visit bulk_edits_path
+    fill_in "q", with: "Haus*"
+    click_on I18n.t("bulk_edits.index.search_button")
+
+    assert_text "Haustier"
+    assert_text "Hausboot"
+    assert_no_text "Schule"
+  end
+
+  test "applying a bulk edit creates a protocol entry" do
+    admin = create(:admin)
+    noun = create(:noun, name: "Haus")
+    phenomenon = create(:phenomenon, name: "Doppelkonsonanz")
+
+    BulkEditService.new(user: admin).execute(
+      word_ids: [noun.id],
+      field: "phenomenons",
+      operation: "add",
+      value: {"ids" => [phenomenon.id]},
+      search_query: "Haus*"
+    )
+
+    login_as admin
+    visit bulk_edits_path
+    assert_text I18n.t("bulk_edits.index.tab_log")
+  end
+
+  test "lecturer can reach the page but cannot undo other users' entries" do
+    admin = create(:admin)
+    lecturer = create(:lecturer)
+    noun = create(:noun, name: "Haus")
+    phenomenon = create(:phenomenon, name: "P")
+
+    admin_edit = BulkEditService.new(user: admin).execute(
+      word_ids: [noun.id], field: "phenomenons", operation: "add", value: {"ids" => [phenomenon.id]}
+    )
+
+    login_as lecturer
+    visit bulk_edits_path
+
+    assert_text I18n.t("bulk_edits.index.title")
+    refute admin_edit.undoable_by?(lecturer)
+    assert admin_edit.undoable_by?(admin)
+  end
+
+  test "denies access to guests" do
+    login_as create(:guest)
+    assert_raises(CanCan::AccessDenied) { visit bulk_edits_path }
+  end
+end

--- a/test/system/filter_test.rb
+++ b/test/system/filter_test.rb
@@ -140,6 +140,15 @@ class FilterTest < ApplicationSystemTestCase
     login_as user
     visit search_path
     click_on t("filter.open")
+
+    # Stop the filter form's `form-submission` Stimulus controller from
+    # firing a fetch on every input event. Otherwise `fill_in "ab"` fires
+    # one fetch per keystroke, each turbo_stream response re-renders the
+    # #add_words_to_list frame, and a click that lands during the re-render
+    # raises ObsoleteNode (or "submits with no list_id" → 404 → no flash).
+    # Set fields silently, then click apply for one deterministic submit.
+    disable_form_auto_submit
+
     fill_in "filterrific[filter_wordstarts]", with: "ab"
     find_button(t("filter.apply"), visible: false).trigger("click")
 
@@ -152,26 +161,10 @@ class FilterTest < ApplicationSystemTestCase
     force_reveal!
     assert_selector "select#list_id", visible: true
 
-    # The add-to-list form lives inside a turbo_frame_tag (:add_words_to_list)
-    # that the filter form's submit may re-render mid-test. Picking the option
-    # via Capybara, then clicking the button as two separate actions, races
-    # that re-render: by the time we click, the <select> we set may have been
-    # replaced by an empty one, the form submits with no list_id, the server
-    # 404s, and we see the empty form instead of the success flash.
-    # Force the value via JS and assert the *outcome* inside a retry loop so
-    # a missed click is caught and the click is re-issued.
-    expected_flash = t("filter.added_words_to_list", count: 3)
-    attempts = 0
-    loop do
-      force_reveal!
-      force_select_value("list_id", list.id.to_s)
-      click_on t("words.show.lists.add")
-      break if page.has_text?(expected_flash, wait: 5)
-      attempts += 1
-      raise "add-to-list flash never appeared after 3 attempts" if attempts >= 3
-    end
+    force_select_value("list_id", list.id.to_s)
+    click_on t("words.show.lists.add")
 
-    assert_text expected_flash
+    assert_text t("filter.added_words_to_list", count: 3)
     assert_equal [noun, verb, adjective].sort_by(&:id), list.words.sort_by(&:id)
   end
 

--- a/test/system/filter_test.rb
+++ b/test/system/filter_test.rb
@@ -151,14 +151,27 @@ class FilterTest < ApplicationSystemTestCase
 
     force_reveal!
     assert_selector "select#list_id", visible: true
-    select list.name, from: "list_id"
 
-    with_node_churn_retry do
+    # The add-to-list form lives inside a turbo_frame_tag (:add_words_to_list)
+    # that the filter form's submit may re-render mid-test. Picking the option
+    # via Capybara, then clicking the button as two separate actions, races
+    # that re-render: by the time we click, the <select> we set may have been
+    # replaced by an empty one, the form submits with no list_id, the server
+    # 404s, and we see the empty form instead of the success flash.
+    # Force the value via JS and assert the *outcome* inside a retry loop so
+    # a missed click is caught and the click is re-issued.
+    expected_flash = t("filter.added_words_to_list", count: 3)
+    attempts = 0
+    loop do
       force_reveal!
+      force_select_value("list_id", list.id.to_s)
       click_on t("words.show.lists.add")
+      break if page.has_text?(expected_flash, wait: 5)
+      attempts += 1
+      raise "add-to-list flash never appeared after 3 attempts" if attempts >= 3
     end
 
-    assert_text t("filter.added_words_to_list", count: 3)
+    assert_text expected_flash
     assert_equal [noun, verb, adjective].sort_by(&:id), list.words.sort_by(&:id)
   end
 


### PR DESCRIPTION
## Summary

Admins and lecturers can now bulk-edit the word catalog at `/seite/bulk_edits`: search with wildcards, pick a field, apply to the selected words, and undo any operation — either entirely or per word — from a Protocol tab.

Field-type behaviour (HABTM, belongs_to, boolean) is encapsulated in a `BulkEdit::FieldStrategy` hierarchy. The service, search/form objects, view helper, and Stimulus controller all dispatch to a strategy; there are no `case field` blocks across layers.

## What you can do

- **Search** with `*`, `?`, `^`, `$` wildcards across word name or syllables; filter by word type, page size, and a "words missing a value in field X" predicate.
- **Pick a field** (10 fields: `topics`, `strategies`, `phenomenons`, `sources`, `hierarchy_id`, `prefix_id`, `postfix_id`, `prototype`, `foreign`, `compound`). The form adapts: HABTM gets a TomSelect with add/remove; belongs_to gets a single-select with an explicit "no value" option; boolean gets a tri-state radio (— / Ja / Nein).
- **Adaptive results column** shows the current value of the chosen field per row.
- **Live preview** above the Apply button: *"Wirkt sich auf 191 von 206 Wörtern aus (15 unverändert)"*. Smart default switches HABTM operation between add/remove based on the current state of the selection. Confirm dialog above 50 affected words.
- **Persistent selection** across pagination via sessionStorage, plus a "select all matches" mode that re-runs the search server-side at apply time.
- **Apply runs inside a Turbo Frame** — scroll position is preserved, only the bulk-edit content swaps.
- **Per-word undo** in the Protocol tab: each row expands (lazy Turbo Frame) to show every affected word with `previous → applied` and a per-word "undo this word" button. Reverting the last pending change auto-closes the parent entry.

## Design highlights

- **Parent + child schema** (`bulk_edits` + `bulk_edit_changes`). Each per-word change records `previous_value` and `applied_value` so an undo restores exactly what was overwritten.
- **`BulkEdit#undoable_by?(user)`** is the single source of truth for who can undo what. The view uses it to show/hide buttons; the controllers use it to authorize the action. No drift.
- **`word.with_lock` + `change.with_lock`** (in deterministic order) make concurrent applies/undos safe.
- **No-op safety**: if no word would actually change, no `BulkEdit` is written and the user gets an inline alert.
- **`BulkEdit::MAX_WORDS_PER_OPERATION = 5_000`** prevents accidental whole-catalog operations.
- **SQL injection guard**: `Word.matching_pattern(query, field:)` whitelists field names via `WordFilter::SEARCHABLE_FIELDS`.

## Tests

- `test/models/bulk_edit_test.rb` — validations, scopes, undoable_by?
- `test/models/bulk_edit_change_test.rb` — scopes, reverted?
- `test/models/bulk_edit/field_strategy/*_test.rb` — one spec per strategy, isolated
- `test/services/bulk_edit_service_test.rb` — apply, undo, undo_change, AlreadyUndone/Reverted, no-op, deleted-word tolerance
- `test/form_objects/forms/bulk_edit_search_test.rb` — wildcards, anchors, missing_field
- `test/form_objects/forms/bulk_edit_form_test.rb` — validations, select_all=1, MAX_WORDS limit
- `test/controllers/bulk_edits_controller_test.rb` — auth edge cases (foreign lecturer, admin can undo any)
- `test/system/bulk_edits_test.rb` — end-to-end through the page

`bin/rails test` passes (321 runs, 806 assertions). `bundle exec standardrb --no-fix` is clean.

## Test plan

- [ ] `bin/rails db:migrate`
- [ ] `bin/rails test` — all green
- [ ] `bundle exec standardrb --no-fix` — no offenses
- [ ] As an admin: search `^Haus*`, set Phänomen on a few words, undo from the Protocol tab — values are restored
- [ ] As an admin: search broader, click "Alle X Treffer auswählen", confirm dialog appears above 50, apply succeeds
- [ ] As a lecturer: same flow works; can only undo own entries, not admin entries
- [ ] As a guest: `/seite/bulk_edits` is denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)