### PR TITLE
Switch Liquid tag registration to Environment API

### DIFF
--- a/app/components/theme_component.rb
+++ b/app/components/theme_component.rb
@@ -25,7 +25,7 @@ class ThemeComponent < ViewComponent::Base
       sanitize_template(template)
     end
 
-    template_renderer = Liquid::Template.parse(sanitized_template)
+    template_renderer = Liquid::Template.parse(sanitized_template, environment: Liquid::Environment.default)
     template_renderer.render(params.with_indifferent_access.merge(view_context:)).html_safe
   end
 

--- a/config/initializers/liquid.rb
+++ b/config/initializers/liquid.rb
@@ -5,6 +5,6 @@ Rails.application.config.to_prepare do
     tag_name = File.basename(filename).gsub(/\.rb$/, "")
     class_name = tag_name.camelize
 
-    Liquid::Template.register_tag(tag_name, class_name.constantize)
+    Liquid::Environment.default.register_tag(tag_name, class_name.constantize)
   end
 end


### PR DESCRIPTION
## Summary

Removes the `[DEPRECATION] Template.register_tag is deprecated. Use Environment#register_tag instead.` warning that printed on every boot and every test run.

Liquid 5.x scopes custom tags to a `Liquid::Environment` instead of mutating global state on `Liquid::Template`. The app uses the global default in both places:

- `config/initializers/liquid.rb` — registers the `box` / `box_grid` block tags on `Liquid::Environment.default`.
- `app/components/theme_component.rb` — passes the same default environment to `Liquid::Template.parse(...)`, so the link between tag registration and parsing is visible in code rather than relying on the implicit global.

The default environment is the same singleton Liquid already used under the hood, so behavior is unchanged — just no more deprecation noise.

## Test plan

- [ ] `bin/rails runner "puts 'ok'"` — no `[DEPRECATION]` line in the output
- [ ] `bin/rails test` — full suite still green
- [ ] `bundle exec standardrb --no-fix` — no offenses
- [ ] Visit a word detail page that uses a theme (e.g. `/abhandlung`) — `{% box %}` / `{% box_grid %}` still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)