### PR TITLE
Fix frozen checkboxes after "select all matches" in bulk editor

### DIFF
--- a/app/javascript/controllers/bulk_select_controller.js
+++ b/app/javascript/controllers/bulk_select_controller.js
@@ -99,12 +99,18 @@ export default class extends Controller {
 
   toggleCheckbox(event) {
     const cb = event.currentTarget
+
+    // Individual click cancels "Alle Treffer"-mode → fall back to explicit selection.
+    // First materialize the currently visible page into the selection, so unchecking
+    // one row keeps the rest of the page selected instead of clearing everything.
+    if (this.allMatches) {
+      this.checkboxTargets.forEach(c => this.idsSet.add(parseInt(c.dataset.wordId, 10)))
+      this.disableAllMatches()
+    }
+
     const wid = parseInt(cb.dataset.wordId, 10)
     if (cb.checked) this.idsSet.add(wid)
     else this.idsSet.delete(wid)
-
-    // Individual click cancels "Alle Treffer"-mode → fall back to explicit selection.
-    if (this.allMatches) this.disableAllMatches()
 
     this.persist()
     this.refreshUI()
@@ -131,7 +137,7 @@ export default class extends Controller {
       this.disableAllMatches()
     } else {
       this.selectAllFieldTarget.value = "1"
-      this.checkboxTargets.forEach(cb => { cb.checked = true; cb.disabled = true })
+      this.checkboxTargets.forEach(cb => { cb.checked = true })
     }
     this.persist()
     this.refreshUI()
@@ -140,7 +146,6 @@ export default class extends Controller {
 
   disableAllMatches() {
     if (this.hasSelectAllFieldTarget) this.selectAllFieldTarget.value = ""
-    this.checkboxTargets.forEach(cb => { cb.disabled = false })
   }
 
   reset() {
@@ -164,14 +169,14 @@ export default class extends Controller {
       const wid = parseInt(cb.dataset.wordId, 10)
       const isSel = this.idsSet.has(wid) || this.allMatches
       cb.checked = isSel
-      cb.disabled = this.allMatches
+      // Checkboxes stay interactive in "Alle Treffer"-mode so a single click can
+      // cancel that mode and fall back to an explicit per-page selection.
       if (isSel) visibleSelected++
     })
 
     if (this.hasPageSelectAllTarget) {
       this.pageSelectAllTarget.checked = visibleSelected > 0 && visibleSelected === visibleTotal
       this.pageSelectAllTarget.indeterminate = visibleSelected > 0 && visibleSelected < visibleTotal
-      this.pageSelectAllTarget.disabled = this.allMatches
     }
 
     let countText

--- a/test/system/bulk_edits_test.rb
+++ b/test/system/bulk_edits_test.rb
@@ -55,6 +55,29 @@ class BulkEditsTest < ApplicationSystemTestCase
     assert admin_edit.undoable_by?(admin)
   end
 
+  test "deselecting a single word after selecting all matches keeps the rest selected" do
+    admin = create(:admin)
+    create(:noun, name: "Hausboot")
+    create(:noun, name: "Haustier")
+    create(:noun, name: "Hausschuh")
+
+    login_as admin
+    visit bulk_edits_path
+    fill_in "q", with: "Haus*"
+    click_on I18n.t("bulk_edits.index.search_button")
+    assert_text "Hausschuh"
+
+    click_on I18n.t("bulk_edits.index.select_all_matches", count: 3)
+    assert_text I18n.t("bulk_edits.index.count_selected", count: 3)
+
+    # The checkbox must stay interactive: unchecking one cancels "all matches" mode
+    # and falls back to an explicit selection of the rest of the page.
+    deselected = Word.find_by!(name: "Haustier")
+    find("input[type=checkbox][data-word-id='#{deselected.id}']").click
+
+    assert_text I18n.t("bulk_edits.index.count_selected", count: 2)
+  end
+
   test "denies access to guests" do
     login_as create(:guest)
     assert_raises(CanCan::AccessDenied) { visit bulk_edits_path }


### PR DESCRIPTION
## What

On the bulk word editor (`/seite/bulk_edits`), clicking **"Alle N Treffer auswählen"** froze every per-row checkbox, so you could no longer select or deselect individual words.

## Why

`toggleAllMatches` set every checkbox to `disabled = true` (and `refreshUI` kept it that way). A disabled checkbox emits no `change` event, so the `bulk-select#toggleCheckbox` handler never fired — making the controller's own documented "click a row to fall back to an explicit selection" path unreachable dead code.

## Fix

- Keep the checkboxes interactive in "all matches" mode instead of disabling them.
- Before leaving all-matches mode on an individual click, materialize the currently visible page into the selection, so unchecking one row keeps the rest of the page selected rather than clearing everything.

Note: because "all matches" is an implicit server-side selection (the IDs aren't tracked per-row across pages), dropping out of that mode can only preserve the **currently visible page** — the cross-page implicit selection is intentionally not retained.

## Test

Added a Cuprite system test in `test/system/bulk_edits_test.rb`: select all 3 matches → assert "3 ausgewählt" → click one row → assert "2 ausgewählt". This fails before the fix (the click did nothing). All bulk-edit system tests pass; standardrb is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)