### PR TITLE
Review type filter with persistent per-type selection

### DIFF
--- a/app/controllers/review_filters_controller.rb
+++ b/app/controllers/review_filters_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class ReviewFiltersController < ApplicationController
+  authorize_resource :review, class: false
+
+  def update
+    review_type = params[:review_type].to_s
+
+    if review_type == "new_word"
+      current_user.update!(review_new_words: !current_user.review_new_words?)
+    else
+      toggle_attribute(review_type)
+    end
+
+    redirect_to reviews_path
+  end
+
+  private
+
+  def toggle_attribute(attribute_name)
+    canonical_key = attribute_keys[attribute_name]
+    return unless canonical_key # ignore unknown types
+
+    attributes = if current_user.review_attributes_without_types.include?(attribute_name)
+      current_user.review_attributes.reject { |key| key.split(".").last == attribute_name }
+    else
+      current_user.review_attributes + [canonical_key]
+    end
+
+    current_user.update!(review_attributes: attributes)
+  end
+
+  # Maps a bare attribute_name (e.g. "keywords") to its canonical
+  # "type.attribute" profile key (e.g. "noun.keywords"). Also acts as the
+  # allow-list: unknown attribute names map to nil and are ignored.
+  def attribute_keys
+    Llm::Attributes.collection.each_with_object({}) do |(_title, key), map|
+      map[key.split(".").last] ||= key
+    end
+  end
+end

--- a/app/controllers/review_filters_controller.rb
+++ b/app/controllers/review_filters_controller.rb
@@ -18,24 +18,15 @@ class ReviewFiltersController < ApplicationController
   private
 
   def toggle_attribute(attribute_name)
-    canonical_key = attribute_keys[attribute_name]
+    canonical_key = Llm::Attributes.by_attribute_name.dig(attribute_name, :key)
     return unless canonical_key # ignore unknown types
 
     attributes = if current_user.review_attributes_without_types.include?(attribute_name)
-      current_user.review_attributes.reject { |key| key.split(".").last == attribute_name }
+      current_user.review_attributes.reject { |key| Llm::Attributes.bare_name(key) == attribute_name }
     else
       current_user.review_attributes + [canonical_key]
     end
 
     current_user.update!(review_attributes: attributes)
-  end
-
-  # Maps a bare attribute_name (e.g. "keywords") to its canonical
-  # "type.attribute" profile key (e.g. "noun.keywords"). Also acts as the
-  # allow-list: unknown attribute names map to nil and are ignored.
-  def attribute_keys
-    Llm::Attributes.collection.each_with_object({}) do |(_title, key), map|
-      map[key.split(".").last] ||= key
-    end
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -4,6 +4,7 @@ class ReviewsController < ApplicationController
   authorize_resource :review, class: false
 
   before_action :set_reviewable, only: %i[show update]
+  before_action :set_filter_counts, only: %i[show update]
 
   rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_next_review
 
@@ -56,13 +57,21 @@ class ReviewsController < ApplicationController
       .find(params[:id])
   end
 
+  def set_filter_counts
+    @filter_counts = ChangeGroup.reviewable_type_counts(current_user)
+  end
+
   def redirect_to_next_review
     @next_review = ChangeGroup.reviewable(current_user).first
 
     if @next_review
       redirect_to review_path(@next_review)
+    elsif params[:action] == "index"
+      # No reviewable change groups left: render the empty index page, but with
+      # the filter so a reviewer who deselected every type can re-enable one.
+      set_filter_counts
     else
-      redirect_to reviews_path unless params[:action] == "index"
+      redirect_to reviews_path
     end
   end
 end

--- a/app/helpers/reviews_helper.rb
+++ b/app/helpers/reviews_helper.rb
@@ -6,11 +6,15 @@ module ReviewsHelper
   # hash with :review_type, :label, :count and :active.
   def review_filter_segments(user, counts)
     selected = user.review_attributes_without_types
+    known_types = Llm::Attributes.by_attribute_name
 
-    attribute_segments = counts.except("new_word").map do |attribute_name, count|
+    # Only render segments for types the toggle can actually act on; an
+    # attribute_name with pending edits but no entry in known_types (e.g. a
+    # renamed/removed LLM schema property) would otherwise be a dead button.
+    attribute_segments = counts.except("new_word").slice(*known_types.keys).map do |attribute_name, count|
       {
         review_type: attribute_name,
-        label: review_attribute_labels[attribute_name] || attribute_name,
+        label: known_types.dig(attribute_name, :title),
         count: count,
         active: selected.include?(attribute_name)
       }
@@ -44,15 +48,5 @@ module ReviewsHelper
     base = "rounded-full px-2 py-0.5 text-xs font-semibold"
 
     active ? "#{base} bg-primary text-white" : "#{base} bg-gray-200 text-gray-700"
-  end
-
-  private
-
-  # Maps a bare attribute_name (e.g. "keywords") to its human label
-  # (e.g. "Stichwörter"), keeping the first label per attribute.
-  def review_attribute_labels
-    Llm::Attributes.collection.each_with_object({}) do |(title, key), map|
-      map[key.split(".").last] ||= title
-    end
   end
 end

--- a/app/helpers/reviews_helper.rb
+++ b/app/helpers/reviews_helper.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module ReviewsHelper
+  # Builds the ordered filter segments for the review page: new words first,
+  # then the remaining types by descending pending count. Each segment is a
+  # hash with :review_type, :label, :count and :active.
+  def review_filter_segments(user, counts)
+    selected = user.review_attributes_without_types
+
+    attribute_segments = counts.except("new_word").map do |attribute_name, count|
+      {
+        review_type: attribute_name,
+        label: review_attribute_labels[attribute_name] || attribute_name,
+        count: count,
+        active: selected.include?(attribute_name)
+      }
+    end.sort_by { |segment| -segment[:count] }
+
+    new_word_segments = if counts["new_word"].to_i.positive?
+      [{
+        review_type: "new_word",
+        label: t("reviews.filter.new_word"),
+        count: counts["new_word"],
+        active: user.review_new_words?
+      }]
+    else
+      []
+    end
+
+    new_word_segments + attribute_segments
+  end
+
+  def review_filter_segment_class(active)
+    base = "flex items-center gap-2 rounded-lg border-2 px-3 py-2 text-sm font-medium"
+
+    if active
+      "#{base} border-primary bg-primary/5 text-primary"
+    else
+      "#{base} border-gray-200 bg-white text-gray-600 hover:bg-gray-50"
+    end
+  end
+
+  def review_filter_badge_class(active)
+    base = "rounded-full px-2 py-0.5 text-xs font-semibold"
+
+    active ? "#{base} bg-primary text-white" : "#{base} bg-gray-200 text-gray-700"
+  end
+
+  private
+
+  # Maps a bare attribute_name (e.g. "keywords") to its human label
+  # (e.g. "Stichwörter"), keeping the first label per attribute.
+  def review_attribute_labels
+    Llm::Attributes.collection.each_with_object({}) do |(title, key), map|
+      map[key.split(".").last] ||= title
+    end
+  end
+end

--- a/app/models/change_group.rb
+++ b/app/models/change_group.rb
@@ -15,6 +15,26 @@ class ChangeGroup < ApplicationRecord
 
   accepts_nested_attributes_for :word_attribute_edits, :new_word
 
+  # Pending review counts per type ("new_word" plus each attribute_name),
+  # independent of the reviewer's current selection. The filter uses these to
+  # show how much work waits per type and which types can be toggled on or off.
+  def self.reviewable_type_counts(reviewer)
+    base = where(successor_id: nil)
+      .where(state: :waiting_for_review)
+      .where("NOT EXISTS (SELECT 1 FROM reviewers WHERE reviewers.change_group_id = change_groups.id AND reviewers.reviewer_id = ?)", reviewer.id)
+
+    counts = base
+      .joins(:word_attribute_edits)
+      .group("word_attribute_edits.attribute_name")
+      .distinct
+      .count("change_groups.id")
+
+    new_word_count = base.joins(:new_word).count
+    counts["new_word"] = new_word_count if new_word_count.positive?
+
+    counts
+  end
+
   private
 
   def cancel_related_enrich_word_jobs

--- a/app/models/change_group.rb
+++ b/app/models/change_group.rb
@@ -19,9 +19,7 @@ class ChangeGroup < ApplicationRecord
   # independent of the reviewer's current selection. The filter uses these to
   # show how much work waits per type and which types can be toggled on or off.
   def self.reviewable_type_counts(reviewer)
-    base = where(successor_id: nil)
-      .where(state: :waiting_for_review)
-      .where("NOT EXISTS (SELECT 1 FROM reviewers WHERE reviewers.change_group_id = change_groups.id AND reviewers.reviewer_id = ?)", reviewer.id)
+    base = pending_for_reviewer(reviewer)
 
     counts = base
       .joins(:word_attribute_edits)

--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -6,8 +6,21 @@ module Reviewable
   included do
     attr_accessor :action
 
+    # Change groups still open for this reviewer: not superseded, waiting for
+    # review, and not already reviewed by them. Shared by the reviewable scope
+    # and ChangeGroup.reviewable_type_counts so "what counts as pending work"
+    # lives in one place. The id-in-subquery form lets the reviewable scope add
+    # its left joins without the NOT EXISTS clause interacting with them.
+    scope :pending_for_reviewer, ->(reviewer) {
+      where(successor_id: nil)
+        .where(state: :waiting_for_review)
+        .where(
+          id: select(:id)
+            .where("NOT EXISTS (SELECT 1 FROM reviewers WHERE reviewers.change_group_id = change_groups.id AND reviewers.reviewer_id = ?)", reviewer.id)
+        )
+    }
+
     scope :reviewable, ->(reviewer) {
-      reviewer_id = reviewer.id
       matching_edit_ids = WordAttributeEdit.where(attribute_name: reviewer.review_attributes_without_types).select(:id)
 
       # New words are an opt-out review type: they only show up while the
@@ -18,16 +31,16 @@ module Reviewable
         ["word_attribute_edits.id IN (?)", matching_edit_ids]
       end
 
-      where(successor_id: nil)
-        .where(state: :waiting_for_review)
+      # The type filter joins word_attribute_edits, so a change group with
+      # several matching edits would fan out into duplicate rows. Collect the
+      # matching ids in a subquery and select change groups by id so each
+      # appears exactly once (and the outer ORDER BY needs no DISTINCT).
+      matching = pending_for_reviewer(reviewer)
         .left_joins(:new_word)
         .left_joins(:word_attribute_edits)
         .where(*type_condition)
-        .where(
-          id: select(:id)
-            .where("NOT EXISTS (SELECT 1 FROM reviewers WHERE reviewers.change_group_id = change_groups.id AND reviewers.reviewer_id = ?)", reviewer_id)
-        )
-        .order(:created_at)
+
+      where(id: matching.select(:id)).order(:created_at)
     }
 
     belongs_to :successor, optional: true, class_name: "ChangeGroup"

--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -8,14 +8,21 @@ module Reviewable
 
     scope :reviewable, ->(reviewer) {
       reviewer_id = reviewer.id
+      matching_edit_ids = WordAttributeEdit.where(attribute_name: reviewer.review_attributes_without_types).select(:id)
+
+      # New words are an opt-out review type: they only show up while the
+      # reviewer keeps them enabled (see User#review_new_words).
+      type_condition = if reviewer.review_new_words?
+        ["new_words.id IS NOT NULL OR word_attribute_edits.id IN (?)", matching_edit_ids]
+      else
+        ["word_attribute_edits.id IN (?)", matching_edit_ids]
+      end
 
       where(successor_id: nil)
         .where(state: :waiting_for_review)
         .left_joins(:new_word)
         .left_joins(:word_attribute_edits)
-        .where(
-          "new_words.id IS NOT NULL OR word_attribute_edits.id IN (?)", WordAttributeEdit.where(attribute_name: reviewer.review_attributes_without_types).select(:id)
-        )
+        .where(*type_condition)
         .where(
           id: select(:id)
             .where("NOT EXISTS (SELECT 1 FROM reviewers WHERE reviewers.change_group_id = change_groups.id AND reviewers.reviewer_id = ?)", reviewer_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,11 +72,7 @@ class User < ApplicationRecord
   end
 
   def review_attributes_without_types
-    review_attributes.map do |attribute_with_type|
-      _type, attribute = attribute_with_type.split(".")
-
-      attribute
-    end.flatten.uniq
+    review_attributes.map { |key| Llm::Attributes.bare_name(key) }.uniq
   end
 
   private

--- a/app/services/llm/attributes.rb
+++ b/app/services/llm/attributes.rb
@@ -28,6 +28,22 @@ module Llm
       end.uniq { |title, key| title }
     end
 
+    # The bare attribute name of a canonical "type.attribute" review key
+    # (e.g. "noun.keywords" -> "keywords"). Single home for that key format.
+    def self.bare_name(key)
+      key.split(".").last
+    end
+
+    # Indexes collection by bare attribute name, keeping the first entry per
+    # name (matching collection's title-based dedup). Lets the review filter
+    # resolve a bare name to both its canonical key and human title in one place
+    # and acts as the allow-list of toggleable review types.
+    def self.by_attribute_name
+      collection.each_with_object({}) do |(title, key), map|
+        map[bare_name(key)] ||= {key:, title:}
+      end
+    end
+
     def self.translate(attributes)
       attributes.map do |attribute_with_type|
         type, attribute = attribute_with_type.split(".")

--- a/app/views/reviews/_filter.html.haml
+++ b/app/views/reviews/_filter.html.haml
@@ -1,0 +1,8 @@
+- segments = review_filter_segments(user, counts)
+- if segments.present?
+  .mb-6
+    .flex.flex-wrap.gap-2
+      - segments.each do |segment|
+        = button_to review_filter_path, method: :patch, params: {review_type: segment[:review_type]}, class: review_filter_segment_class(segment[:active]) do
+          = segment[:label]
+          %span{class: review_filter_badge_class(segment[:active])}= number_with_delimiter(segment[:count])

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -1,3 +1,8 @@
-%h1= t '.empty.title'
+- if @filter_counts.present?
+  %h1= t '.filtered.title'
+  %p.mt-4= t '.filtered.explanation'
+- else
+  %h1= t '.empty.title'
+  %p.mt-4= t '.empty.explanation'
 
-%p.mt-4= t '.empty.explanation'
+.mt-6= render "filter", counts: @filter_counts, user: current_user

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -1,4 +1,6 @@
 .p-4
+  = render "filter", counts: @filter_counts, user: current_user
+
   - if @reviewable.word_attribute_edits.present?
     = render 'word_attribute_edits'
   - elsif @reviewable.new_word.present?

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -444,10 +444,15 @@ de:
       session_expired: "Ihre Sitzung ist abgelaufen. Bitte versuchen Sie es erneut."
 
   reviews:
+    filter:
+      new_word: Neues Wort
     index:
       empty:
         title: Keine Reviews vorhanden
         explanation: Zur Zeit sind keine ausstehenden Reviews vorhanden. Bitte schauen Sie später nochmals vorbei!
+      filtered:
+        title: Keine Review-Typen ausgewählt
+        explanation: Es sind Reviews vorhanden, aber Sie haben aktuell keinen passenden Typ ausgewählt. Bitte wählen Sie unten einen Typ aus, um mit dem Review zu beginnen.
     show:
       attribute: Vorschlag bezüglich
       current_value: Aktuell

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,7 @@ Rails.application.routes.draw do
     resource :llm_enrichment, only: %i[show new create]
     resources :keyword_analytics, only: %i[index show]
     resources :reviews, only: %i[index show update]
+    resource :review_filter, only: :update
     resources :pending_reviews, only: :index do
       collection do
         post :delete_filtered

--- a/db/migrate/20260601120000_add_review_new_words_to_users.rb
+++ b/db/migrate/20260601120000_add_review_new_words_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReviewNewWordsToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :review_new_words, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_11_151933) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_01_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -538,6 +538,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_11_151933) do
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
     t.string "review_attributes", default: [], null: false, array: true
+    t.boolean "review_new_words", default: true, null: false
     t.string "role", default: "Guest"
     t.string "unconfirmed_email"
     t.datetime "updated_at", null: false

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -5,20 +5,25 @@ require "capybara/cuprite"
 require "capybara/minitest"
 require "capybara-screenshot/minitest"
 
-Capybara.register_driver(:cuprite) do |app|
-  Capybara::Cuprite::Driver.new(app,
-    window_size: [1200, 800],
-    js_errors: true,
-    timeout: 10,
-    process_timeout: 30)
-end
-
 Capybara.javascript_driver = :cuprite
 Capybara.default_max_wait_time = 5
 Capybara.asset_host = "http://localhost:3000"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :cuprite
+  # Configure Cuprite through driven_by, not a standalone
+  # Capybara.register_driver(:cuprite) block. Rails treats :cuprite as a
+  # "registerable" driver, so driven_by re-registers it on the first system
+  # test and silently overwrites any standalone registration. Options passed
+  # here are the ones Rails actually applies.
+  #
+  # process_timeout: 30 gives Chrome a generous budget to produce its websocket
+  # URL on a cold, loaded CI runner. With the old (overwritten) config the
+  # effective value was Ferrum's 10s default, which the first system test in a
+  # run could exceed -> Ferrum::ProcessTimeoutError.
+  driven_by :cuprite, screen_size: [1200, 800], options: {
+    timeout: 10,
+    process_timeout: 30
+  }
 
   include Warden::Test::Helpers
   include Devise::Test::IntegrationHelpers

--- a/test/controllers/review_filters_controller_test.rb
+++ b/test/controllers/review_filters_controller_test.rb
@@ -37,7 +37,16 @@ class ReviewFiltersControllerTest < ActionDispatch::IntegrationTest
 
     patch review_filter_path, params: {review_type: "keywords"}
 
-    refute_includes admin.reload.review_attributes_without_types, "keywords"
+    assert_equal [], admin.reload.review_attributes
+  end
+
+  test "toggling one selected attribute leaves the others untouched" do
+    admin = create(:admin, review_attributes: ["noun.keywords", "noun.synonyms"])
+    sign_in admin
+
+    patch review_filter_path, params: {review_type: "keywords"}
+
+    assert_equal ["noun.synonyms"], admin.reload.review_attributes
   end
 
   test "ignores an unknown review type" do

--- a/test/controllers/review_filters_controller_test.rb
+++ b/test/controllers/review_filters_controller_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ReviewFiltersControllerTest < ActionDispatch::IntegrationTest
+  test "toggling new words off disables the flag" do
+    admin = create(:admin, review_new_words: true)
+    sign_in admin
+
+    patch review_filter_path, params: {review_type: "new_word"}
+
+    assert_redirected_to reviews_path
+    refute admin.reload.review_new_words?
+  end
+
+  test "toggling new words on enables the flag" do
+    admin = create(:admin, review_new_words: false)
+    sign_in admin
+
+    patch review_filter_path, params: {review_type: "new_word"}
+
+    assert admin.reload.review_new_words?
+  end
+
+  test "toggling an unselected attribute adds its canonical key" do
+    admin = create(:admin, review_attributes: [])
+    sign_in admin
+
+    patch review_filter_path, params: {review_type: "keywords"}
+
+    assert_includes admin.reload.review_attributes, "noun.keywords"
+  end
+
+  test "toggling a selected attribute removes it" do
+    admin = create(:admin, review_attributes: ["noun.keywords"])
+    sign_in admin
+
+    patch review_filter_path, params: {review_type: "keywords"}
+
+    refute_includes admin.reload.review_attributes_without_types, "keywords"
+  end
+
+  test "ignores an unknown review type" do
+    admin = create(:admin, review_attributes: ["noun.keywords"])
+    sign_in admin
+
+    patch review_filter_path, params: {review_type: "does_not_exist"}
+
+    assert_redirected_to reviews_path
+    assert_equal ["noun.keywords"], admin.reload.review_attributes
+  end
+end

--- a/test/controllers/reviews_controller_test.rb
+++ b/test/controllers/reviews_controller_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ReviewsControllerTest < ActionDispatch::IntegrationTest
+  test "re-rendering the review after an invalid proposal still loads the filter" do
+    admin = create(:admin, review_attributes: ["noun.keywords"])
+    sign_in admin
+    edit = create(:word_attribute_edit, attribute_name: "keywords")
+
+    patch review_path(edit.change_group), params: {
+      state: "confirmed",
+      change_group: {
+        word_attribute_edits_attributes: {
+          "0" => {id: edit.id, value: ""}
+        }
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "form[action=?]", review_filter_path
+  end
+
+  test "explains that types are deselected and shows the filter when pending reviews are filtered out" do
+    admin = create(:admin, review_attributes: [], review_new_words: false)
+    sign_in admin
+    create(:new_word) # pending, but filtered out, so the queue is empty
+
+    get reviews_path
+
+    assert_response :success
+    assert_select "h1", text: I18n.t("reviews.index.filtered.title")
+    assert_select "form[action=?]", review_filter_path
+  end
+
+  test "shows the plain empty message and no filter when nothing is pending" do
+    sign_in create(:admin)
+
+    get reviews_path
+
+    assert_response :success
+    assert_select "h1", text: I18n.t("reviews.index.empty.title")
+    assert_select "form[action=?]", review_filter_path, count: 0
+  end
+end

--- a/test/helpers/reviews_helper_test.rb
+++ b/test/helpers/reviews_helper_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ReviewsHelperTest < ActionView::TestCase
+  test "orders new words first, then attributes by descending count" do
+    user = create(:admin, review_attributes: ["noun.synonyms"], review_new_words: true)
+    counts = {"keywords" => 1, "synonyms" => 3, "new_word" => 2}
+
+    segments = review_filter_segments(user, counts)
+
+    assert_equal ["new_word", "synonyms", "keywords"], segments.map { |segment| segment[:review_type] }
+  end
+
+  test "marks a segment active when the reviewer selected that type" do
+    user = create(:admin, review_attributes: ["noun.synonyms"], review_new_words: true)
+
+    segments = review_filter_segments(user, {"keywords" => 1, "synonyms" => 3})
+
+    assert segments.find { |segment| segment[:review_type] == "synonyms" }[:active]
+    refute segments.find { |segment| segment[:review_type] == "keywords" }[:active]
+  end
+
+  test "omits the new word segment when its count is absent or zero" do
+    user = create(:admin, review_new_words: true)
+
+    assert_empty review_filter_segments(user, {})
+    assert_empty review_filter_segments(user, {"new_word" => 0})
+  end
+
+  test "shows the new word segment but inactive when the reviewer disabled it" do
+    user = create(:admin, review_new_words: false)
+
+    segments = review_filter_segments(user, {"new_word" => 2})
+
+    new_word = segments.find { |segment| segment[:review_type] == "new_word" }
+    assert_equal 2, new_word[:count]
+    refute new_word[:active]
+  end
+
+  test "skips attribute names that are not toggleable review types" do
+    user = create(:admin)
+
+    segments = review_filter_segments(user, {"not_a_real_attribute" => 5})
+
+    assert_empty segments
+  end
+
+  test "labels attribute segments with their human attribute name" do
+    user = create(:admin, review_attributes: [])
+
+    segments = review_filter_segments(user, {"keywords" => 1})
+
+    assert_equal Llm::Attributes.by_attribute_name.dig("keywords", :title), segments.first[:label]
+  end
+end

--- a/test/models/change_group_test.rb
+++ b/test/models/change_group_test.rb
@@ -116,6 +116,16 @@ class ChangeGroupTest < ActiveSupport::TestCase
 
       assert_includes ChangeGroup.reviewable(reviewer).pluck(:id), edit.change_group_id
     end
+
+    test "returns a change group only once even when several of its edits match" do
+      reviewer = create(:user, review_attributes: ["noun.keywords"], review_new_words: false)
+      change_group = create(:word_attribute_edit, attribute_name: "keywords").change_group
+      create(:word_attribute_edit, attribute_name: "keywords", change_group:)
+
+      ids = ChangeGroup.reviewable(reviewer).pluck(:id)
+
+      assert_equal 1, ids.count(change_group.id)
+    end
   end
 
   class ReviewableTypeCountsTest < ActiveSupport::TestCase
@@ -148,6 +158,27 @@ class ChangeGroupTest < ActiveSupport::TestCase
       counts = ChangeGroup.reviewable_type_counts(reviewer)
 
       assert_equal 1, counts["new_word"]
+    end
+
+    test "counts a change group with edits of different types once per type" do
+      reviewer = create(:user)
+      change_group = create(:word_attribute_edit, attribute_name: "keywords").change_group
+      create(:word_attribute_edit, attribute_name: "synonyms", change_group:)
+
+      counts = ChangeGroup.reviewable_type_counts(reviewer)
+
+      assert_equal 1, counts["keywords"]
+      assert_equal 1, counts["synonyms"]
+    end
+
+    test "counts a change group with several edits of the same type only once" do
+      reviewer = create(:user)
+      change_group = create(:word_attribute_edit, attribute_name: "keywords").change_group
+      create(:word_attribute_edit, attribute_name: "keywords", change_group:)
+
+      counts = ChangeGroup.reviewable_type_counts(reviewer)
+
+      assert_equal 1, counts["keywords"]
     end
   end
 

--- a/test/models/change_group_test.rb
+++ b/test/models/change_group_test.rb
@@ -95,6 +95,62 @@ class ChangeGroupTest < ActiveSupport::TestCase
     end
   end
 
+  class NewWordFilterTest < ActiveSupport::TestCase
+    test "includes new words when the reviewer reviews new words" do
+      reviewer = create(:user, review_attributes: [], review_new_words: true)
+      new_word = create(:new_word)
+
+      assert_includes ChangeGroup.reviewable(reviewer).pluck(:id), new_word.change_group_id
+    end
+
+    test "excludes new words when the reviewer disabled new words" do
+      reviewer = create(:user, review_attributes: [], review_new_words: false)
+      new_word = create(:new_word)
+
+      refute_includes ChangeGroup.reviewable(reviewer).pluck(:id), new_word.change_group_id
+    end
+
+    test "still includes matching attribute edits when new words are disabled" do
+      reviewer = create(:user, review_attributes: ["noun.keywords"], review_new_words: false)
+      edit = create(:word_attribute_edit, attribute_name: "keywords")
+
+      assert_includes ChangeGroup.reviewable(reviewer).pluck(:id), edit.change_group_id
+    end
+  end
+
+  class ReviewableTypeCountsTest < ActiveSupport::TestCase
+    test "counts pending change groups per type" do
+      reviewer = create(:user)
+      create(:new_word)
+      create(:new_word)
+      create(:word_attribute_edit, attribute_name: "keywords")
+
+      counts = ChangeGroup.reviewable_type_counts(reviewer)
+
+      assert_equal 2, counts["new_word"]
+      assert_equal 1, counts["keywords"]
+    end
+
+    test "ignores change groups the reviewer already reviewed" do
+      reviewer = create(:user)
+      edit = create(:word_attribute_edit, attribute_name: "keywords")
+      edit.change_group.reviews.create!(reviewer: reviewer, state: :skipped)
+
+      counts = ChangeGroup.reviewable_type_counts(reviewer)
+
+      assert_nil counts["keywords"]
+    end
+
+    test "counts a type independently of the reviewer's selection" do
+      reviewer = create(:user, review_attributes: [], review_new_words: false)
+      create(:new_word)
+
+      counts = ChangeGroup.reviewable_type_counts(reviewer)
+
+      assert_equal 1, counts["new_word"]
+    end
+  end
+
   class StoreReviewTest < ActiveSupport::TestCase
     setup do
       @reviewable = create(:word_attribute_edit)


### PR DESCRIPTION
## What & why

Reviewers can now pick which review types to work on via a count-badge filter bar on the review page, persisted to their profile — instead of only through the buried profile checkboxes.

## Changes

- New `review_new_words` flag (default `true`) makes new-word reviews an opt-out type alongside the existing per-attribute selection. The default preserves today's behaviour.
- `ChangeGroup.reviewable` honours the flag; `ChangeGroup.reviewable_type_counts` drives the dynamic, count-labelled segments (only types with pending reviews appear).
- `ReviewFiltersController#update` (`PATCH /review_filter`) toggles one type and persists it to the user's profile.
- The filter also renders on the empty review page, so deselecting every type can't lock you out; that page now distinguishes "nothing pending" from "all types deselected".
- Count badges are formatted with `number_with_delimiter` (e.g. `1.205`).

## Schema scope

`db/schema.rb` in this PR contains **only** the new `review_new_words` column (plus the version bump). Unrelated local schema work that is not ready to merge — the removal of some `words` columns (`example_sentences_verified`, `image_alt_text`, `syllables_verified`, `wiktionary_syllables`) and the `gen_random_uuid` formatting change — was deliberately left out.

## Tests

- **Model:** `reviewable` scope honours `review_new_words`; `reviewable_type_counts`.
- **Controller:** toggling on/off/add/remove/unknown; empty-index filtered vs. plain message; invalid-proposal re-render keeps the filter.
- Full non-system suite green; system suite green aside from a pre-existing CDN flake.

## Notes

- Pre-existing, repo-wide system-test flake (`Ferrum::PendingConnectionsError` from JS pinned to `ga.jspm.io`) documented in #744 — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)