### PR TITLE
Harden "adds filtered words to a list" system test against a Turbo re-render race

### DIFF
--- a/test/system/filter_test.rb
+++ b/test/system/filter_test.rb
@@ -162,10 +162,18 @@ class FilterTest < ApplicationSystemTestCase
     force_reveal!
     assert_selector "select#list_id", visible: true
 
-    force_select_value("list_id", list.id.to_s)
-    click_on t("words.show.lists.add")
+    # Selecting the list dispatches a `change` that re-renders the
+    # #add_words_to_list turbo_frame; a click that lands during that
+    # re-render detaches the "add" button and raises ObsoleteNode. Retry the
+    # select-and-submit as a unit and assert the outcome inside the block, so
+    # a click swallowed by the re-render is retried instead of silently lost.
+    with_node_churn_retry do
+      force_select_value("list_id", list.id.to_s)
+      click_on t("words.show.lists.add")
 
-    assert_text t("filter.added_words_to_list", count: 3)
+      assert_text t("filter.added_words_to_list", count: 3)
+    end
+
     assert_equal [noun, verb, adjective].sort_by(&:id), list.words.sort_by(&:id)
   end
 


### PR DESCRIPTION
The `FilterTest#test_adds_filtered_words_to_a_list` system test intermittently fails on CI with `Capybara::Cuprite::ObsoleteNode` at the "add to list" click (`filter_test.rb:166`).

## Cause
Selecting the list via `force_select_value` dispatches a `change` event that re-renders the `#add_words_to_list` turbo_frame. When the subsequent click lands during that re-render, the button node is already detached and Cuprite raises `ObsoleteNode`.

## Fix
Wrap the select-and-submit in the existing `with_node_churn_retry` helper and move the success assertion *inside* the retry block, matching the project convention for DOM churn documented in `CLAUDE.md`. A click swallowed by the re-render is now retried, and the in-block assertion guarantees a no-op click is caught rather than silently accepted.

## Verification
- Target test run 5× in a row locally: green every time.
- Full `filter_test.rb` system run: 271 runs, 0 failures, 0 errors.
- `standardrb --no-fix test/system/filter_test.rb`: no offenses.

This is the flake that was blocking the faraday 2.14.2 bump (#740); it is unrelated to faraday and affects the suite on `main`.