### PR TITLE
Fix word detail pages crashing on double-serialized example_sentences (#751)

### DIFF
--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -85,6 +85,25 @@ class Word < ApplicationRecord
       .count(&:present?)
   end
 
+  # example_sentences is a JSONB column that is meant to hold an Array of
+  # strings. Some legacy rows were written double-serialized: the JSON string
+  # "[]" instead of the array [], so the attribute reads back as a String and
+  # broke every word detail page (issue #751). Normalize on read so views can
+  # always call #each, regardless of what the column happens to contain. A data
+  # migration cleans up the stored values; this guard keeps reads safe.
+  def example_sentences
+    value = super
+
+    case value
+    when Array
+      value
+    when String
+      normalize_serialized_example_sentences(value)
+    else
+      []
+    end
+  end
+
   def assign_compound_entities(compound_entity_ids)
     service = CompoundEntityService.new(self)
     self.compound_entities = service.assign_compound_entities(compound_entity_ids)
@@ -151,6 +170,13 @@ class Word < ApplicationRecord
     example_sentences
       .map!(&:strip)
       .select!(&:present?)
+  end
+
+  def normalize_serialized_example_sentences(value)
+    parsed = JSON.parse(value)
+    parsed.is_a?(Array) ? parsed : []
+  rescue JSON::ParserError
+    []
   end
 
   def cologne_phonetics_terms

--- a/db/migrate/20260603071237_fix_double_serialized_example_sentences.rb
+++ b/db/migrate/20260603071237_fix_double_serialized_example_sentences.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Some word rows stored their example_sentences JSONB column double-serialized:
+# the JSON *string* "[]" (or "[\"a\", \"b\"]") instead of the JSON *array*
+# [] / ["a", "b"]. That made Word#example_sentences read back a String and
+# crashed every word detail page (issue #751).
+#
+# Unwrap the inner JSON text (#>> '{}') and re-cast it to jsonb so the column
+# holds a real array again. We only touch rows whose value is a JSON string
+# that looks like an array; anything else is left untouched and handled
+# defensively by the model reader.
+class FixDoubleSerializedExampleSentences < ActiveRecord::Migration[8.1]
+  def up
+    execute(<<~'SQL')
+      UPDATE words
+      SET example_sentences = (example_sentences #>> '{}')::jsonb
+      WHERE jsonb_typeof(example_sentences) = 'string'
+        AND (example_sentences #>> '{}') ~ '^\s*\['
+    SQL
+  end
+
+  def down
+    # Re-corrupting the data would serve no purpose, so there is nothing to undo.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_01_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_03_071237) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"

--- a/test/controllers/nouns_controller_test.rb
+++ b/test/controllers/nouns_controller_test.rb
@@ -129,4 +129,15 @@ class NounsControllerTest < ActionDispatch::IntegrationTest
     refute_includes json_response["image_url"], "/redirect/"
     assert_no_match(/[?&]exp=/, json_response["image_url"])
   end
+
+  test "#show renders even when example_sentences is double-serialized in the database" do
+    # Reproduce the production data bug (issue #751): the JSONB column holds the
+    # JSON string "[]" instead of the array []. update_column bypasses the model
+    # writer and the sanitizer, mirroring the bad rows already in the database.
+    @word.update_column(:example_sentences, "[]")
+
+    get noun_path(@word)
+
+    assert_response :success
+  end
 end

--- a/test/models/word_test.rb
+++ b/test/models/word_test.rb
@@ -77,6 +77,26 @@ class WordTest < ActiveSupport::TestCase
     assert_equal [], word.example_sentences
   end
 
+  test "#example_sentences returns an array when the column holds a double-serialized empty array" do
+    word = create(:noun, name: "Haus")
+    # Reproduce the production data bug (issue #751): the JSONB column holds the
+    # JSON string "[]" instead of the array []. update_column bypasses the model
+    # writer and the sanitizer, mirroring the bad rows already in the database.
+    word.update_column(:example_sentences, "[]")
+    word.reload
+
+    assert_instance_of Array, word.example_sentences
+    assert_equal [], word.example_sentences
+  end
+
+  test "#example_sentences parses a double-serialized array back into an array" do
+    word = create(:noun, name: "Haus")
+    word.update_column(:example_sentences, %(["Satz eins", "Satz zwei"]))
+    word.reload
+
+    assert_equal ["Satz eins", "Satz zwei"], word.example_sentences
+  end
+
   test "#set_consonant_vowel detects vowels and consonants" do
     word = create(:noun, name: "Ähre")
     assert_equal "VKKV", word.consonant_vowel


### PR DESCRIPTION
Closes #751.

## Problem
Every word detail page (`/prinz`, `/stempeln`, ...) raised:

```
NoMethodError: undefined method 'each' for an instance of String
  app/views/example_sentences/_list.html.haml:4
```

The `example_sentences` JSONB column held the **double-serialized** JSON string `"[]"` instead of the array `[]`, so the attribute read back as a `String`. The show view calls `#each` on it.

## Fix (two parts, as scoped in the issue)
1. **Read-side guard** — `Word#example_sentences` now normalizes on read and always returns an `Array`: it parses a double-serialized JSON string back into its array, and falls back to `[]` for anything unexpected. Pages stop crashing immediately, even before the data is cleaned.
2. **Data migration** — `FixDoubleSerializedExampleSentences` unwraps the inner JSON text and re-casts it to jsonb (`(example_sentences #>> '{}')::jsonb`) for the rows whose value is a JSON string that looks like an array. It is restricted with `jsonb_typeof = 'string'` and a `~ '^\s*\['` guard so it can't choke on non-array junk; the model reader covers anything the migration skips.

## Tests (written first, confirmed red → green)
- Model: `Word#example_sentences` returns an array for a double-serialized `"[]"`, and parses a double-serialized array back into a real array.
- Request: `NounsController#show` renders `200` for a noun whose `example_sentences` is double-serialized in the DB (this reproduced the exact production 500 before the fix).

Full non-system suite green (348 runs, 0 failures). `standardrb` clean.

## Note for reviewers
`db/schema.rb` contains **only** the migration version bump. The migration is data-only (no DDL), so there is no structural schema change.