### PR TITLE
Fix detail pages crashing when no LLM service is active (#752)

### DIFF
--- a/app/services/llm/invoke.rb
+++ b/app/services/llm/invoke.rb
@@ -60,7 +60,7 @@ module Llm
     end
 
     def default_model
-      LlmService.active.model
+      LlmService.active&.model
     end
 
     def output_parser

--- a/test/services/llm/invoke_test.rb
+++ b/test/services/llm/invoke_test.rb
@@ -12,6 +12,26 @@ class Llm::InvokeTest < ActiveSupport::TestCase
     )
   end
 
+  def build_invoke_with_default_model
+    Llm::Invoke.new(
+      prompt: "Test prompt",
+      prompt_variables: {word: "Test"},
+      response_model: Llm::Schema::Keywords
+    )
+  end
+
+  test "#model defaults to the active LlmService's model" do
+    create(:llm_service, model: "llama3.1")
+    assert_equal "llama3.1", build_invoke_with_default_model.model
+  end
+
+  test "building without a model does not raise when no LlmService is active" do
+    # Issue #752: with no active LLM service, default_model called .model on
+    # nil and crashed the (function word) detail pages that build an Invoke.
+    assert_nil LlmService.active
+    assert_nil build_invoke_with_default_model.model
+  end
+
   test "#gpt5_model? returns false for gpt-4" do
     assert_equal false, build_invoke("gpt-4").send(:gpt5_model?)
   end


### PR DESCRIPTION
Closes #752.

## Problem
Word detail pages that build an `Llm::Invoke` (e.g. FunctionWord pages, via ThemeComponent's prompt-preview UI) raised:

```
NoMethodError: undefined method 'model' for nil
  app/services/llm/invoke.rb:63
```

whenever no `LlmService` was marked active. `Invoke#default_model` is the default value of the `model:` kwarg, evaluated eagerly on construction, and it called `.model` straight on `LlmService.active` (which is `nil` when nothing is configured).

## Fix
Safe navigation: `LlmService.active&.model`. With no active service the default model is `nil` instead of raising.

## Tests (written first, confirmed red → green)
Unit test on `Llm::Invoke`:
- Building without an explicit `model:` no longer raises when `LlmService.active` is `nil`.
- Still defaults to the active service's `model` when one exists (no regression).

Full non-system suite green (347 runs, 0 failures). `standardrb` clean.

## Note for reviewers
The original issue (#750) also claimed `theme_component.html.haml` instantiates `Llm::Enrich.new(word:)` unconditionally. It does not — that path is already guarded by `can?(:manage_llm, word) && !Rails.env.test?`, so no change there. That same `!Rails.env.test?` guard is why this is covered by a unit test rather than a request test.