### PR TITLE
Fix profile themes page crashing on theme_noun for User/Admin (#753)

### DIFF
--- a/app/controllers/profiles/themes_controller.rb
+++ b/app/controllers/profiles/themes_controller.rb
@@ -9,16 +9,32 @@ module Profiles
 
     def index
       @themes = @themes.order(:name).where(word_type:).page(params[:page])
-      @active_theme = current_user.public_send(theme_attribute)
+      @active_theme = current_user.word_view_setting&.public_send(theme_attribute)
     end
 
     def update
-      current_user.update!(theme_attribute => chosen_theme)
+      word_view_setting.update!(theme_attribute => chosen_theme)
 
       redirect_to profile_path
     end
 
     private
+
+    # The per-word-type themes used to be columns on User; they now live on the
+    # user's WordViewSetting. A user may not have one yet, so create and link one
+    # the first time they pick a theme so the preference has somewhere to live.
+    def word_view_setting
+      current_user.word_view_setting || create_word_view_setting
+    end
+
+    def create_word_view_setting
+      setting = WordViewSetting.create!(
+        name: t("profiles.themes.update.default_word_view_setting_name", name: current_user.to_s),
+        owner: current_user
+      )
+      current_user.update!(word_view_setting: setting)
+      setting
+    end
 
     def chosen_theme
       if params[:id] == "0"

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -12,6 +12,8 @@ de:
     themes:
       index:
         back_to_profile: Zurück zum Profil
+      update:
+        default_word_view_setting_name: Ansicht von %{name}
   users:
     passwords:
       edit:

--- a/test/controllers/profiles/themes_controller_test.rb
+++ b/test/controllers/profiles/themes_controller_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Profiles
+  class ThemesControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @user = create(:user)
+      sign_in @user
+    end
+
+    test "#index renders for a user who has a word view setting" do
+      setting = create(:word_view_setting, owner: @user)
+      @user.update!(word_view_setting: setting)
+
+      get profile_themes_path(word_type: "noun")
+
+      assert_response :success
+    end
+
+    test "#index renders for a user without a word view setting" do
+      assert_nil @user.word_view_setting
+
+      get profile_themes_path(word_type: "noun")
+
+      assert_response :success
+    end
+
+    test "#update stores the chosen theme on the user's word view setting" do
+      setting = create(:word_view_setting, owner: @user)
+      @user.update!(word_view_setting: setting)
+      theme = create(:theme, word_type: :noun, visibility: :public)
+
+      patch profile_theme_path(theme, word_type: "noun")
+
+      assert_redirected_to profile_path
+      assert_equal theme, setting.reload.theme_noun
+    end
+
+    test "#update creates a word view setting on the fly when the user has none" do
+      assert_nil @user.word_view_setting
+      theme = create(:theme, word_type: :noun, visibility: :public)
+
+      assert_difference -> { WordViewSetting.count }, 1 do
+        patch profile_theme_path(theme, word_type: "noun")
+      end
+
+      assert_redirected_to profile_path
+      setting = @user.reload.word_view_setting
+      assert_not_nil setting
+      assert_equal @user, setting.owner
+      assert_equal theme, setting.theme_noun
+    end
+
+    test "#update can reset the theme to the standard with id 0" do
+      theme = create(:theme, word_type: :noun)
+      setting = create(:word_view_setting, owner: @user, theme_noun: theme)
+      @user.update!(word_view_setting: setting)
+
+      patch profile_theme_path(0, word_type: "noun")
+
+      assert_redirected_to profile_path
+      assert_nil setting.reload.theme_noun
+    end
+  end
+end


### PR DESCRIPTION
Closes #753.

## Problem
`/seite/profile/themes` raised, on **both** `index` and `update`:

```
NoMethodError: undefined method 'theme_noun' for an instance of <User>
  app/controllers/profiles/themes_controller.rb:12 (and :16)
```

The per-word-type accessors (`theme_noun`, `theme_verb`, `theme_adjective`, `theme_function_word`) were moved from `User` to `WordViewSetting`, but `Profiles::ThemesController` still called them on `current_user`. The page had **no** controller/request test, which is how the regression shipped.

## Fix
Route reads and writes through the user's `word_view_setting`:

- **index** reads `current_user.word_view_setting&.public_send(theme_attribute)` — a user without a setting simply has no active theme instead of crashing.
- **update** writes to the `word_view_setting`. A user may not have one yet (it's `optional` and assigned via the profile form, not created at signup), so we **create and link one on the fly** the first time they pick a theme, named `Ansicht von <user>` (locale key `profiles.themes.update.default_word_view_setting_name`, easy to tweak). This restores the pre-migration behavior where any user could set their themes.

## Tests (written first, confirmed red → green)
New `Profiles::ThemesControllerTest`:
- `index` renders for a user **with** and **without** a word view setting.
- `update` stores the chosen theme on an existing setting.
- `update` **auto-creates** a setting (owned by the user) when none exists.
- `update` resets to the standard theme via `id = 0`.

Full non-system suite green (350 runs, 0 failures). `standardrb` clean.

## Decision captured
When a user with no `word_view_setting` picks a theme, `update` auto-creates one (your call). The default name lives in the locale file so you can reword it.

## Out of scope (flagging)
`app/components/user_profile_theme_component.html.haml:2` has the same latent `@user.public_send("theme_#{word_type}")` bug, but the component is rendered nowhere (dead code), so I left it untouched. Happy to clean it up or delete it in a follow-up if you'd like.