### PR TITLE
Massenbearbeitung: Auswahlmenü für Sammelfelder (Strategien/Phänomene) wieder aktivieren

### DIFF
--- a/app/javascript/controllers/bulk_edit_form_controller.js
+++ b/app/javascript/controllers/bulk_edit_form_controller.js
@@ -72,6 +72,16 @@ export default class extends Controller {
       el.style.display = matches ? "" : "none"
       el.querySelectorAll("input, select").forEach(input => {
         input.disabled = !matches
+        // TomSelect wraps the native <select> and doesn't observe its `disabled`
+        // property, so toggling it above leaves the widget greyed-out. Drive the
+        // widget's own enable/disable API to keep the active picker interactive.
+        if (input.tomselect) {
+          if (matches) {
+            input.tomselect.enable()
+          } else {
+            input.tomselect.disable()
+          }
+        }
       })
     })
 

--- a/test/system/bulk_edits_test.rb
+++ b/test/system/bulk_edits_test.rb
@@ -82,4 +82,30 @@ class BulkEditsTest < ApplicationSystemTestCase
     login_as create(:guest)
     assert_raises(CanCan::AccessDenied) { visit bulk_edits_path }
   end
+
+  test "choosing a collection field reveals an interactive value picker" do
+    admin = create(:admin)
+    create(:noun, name: "Haus")
+    create(:strategy, name: "Kurze Vokale")
+    create(:phenomenon, name: "Diphthong - au")
+
+    login_as admin
+    visit bulk_edits_path
+    fill_in "q", with: "Haus*"
+    click_on I18n.t("bulk_edits.index.search_button")
+    assert_text "Haus"
+
+    # Regression: the TomSelect widgets for the collection fields (strategies,
+    # phenomenons, …) were initialised while disabled and stayed greyed-out, so
+    # nothing could be picked. Selecting the field must yield an *enabled* widget.
+    %w[strategies phenomenons].each do |field|
+      label = field.classify.constantize.model_name.human(count: 2)
+      select label, from: "field"
+
+      within "[data-bulk-edit-form-target='valueInput'][data-field='#{field}']" do
+        assert_selector ".ts-control"
+        assert_no_selector ".ts-wrapper.disabled"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Hi Stefan 👋

Frank ist beim Testen der Massenbearbeitung aufgefallen, dass man im Block **„Felder zuweisen"** bei den Feldern **Rechtschreibphänomene** und **Rechtschreibstrategie** nichts auswählen kann – das Auswahlmenü rechts ist ausgegraut/inaktiv. Das Gleiche betrifft auch die anderen Sammelfelder (**Themen**, **Quellen**), weil sie technisch identisch funktionieren.

## Was war kaputt?

Die Sammelfelder (HABTM) nutzen das JS-Widget **TomSelect** (`data-controller="select"`), das den normalen `<select>` mit einem hübschen Mehrfach-Auswahlmenü überlagert.

Der Ablauf beim Laden der Seite:

1. Der `bulk-edit-form`-Stimulus-Controller hängt am `<form>` (Elternelement) und verbindet sich **zuerst**. In `connect()` ruft er `toggleInputs()` auf. Da zu diesem Zeitpunkt **noch kein Feld** gewählt ist, **deaktiviert er sämtliche** Wert-Eingaben (`input.disabled = true`) – damit beim Absenden nur das aktive Feld mitgeschickt wird.
2. **Danach** initialisiert sich der `select`-Controller auf jedem `<select>` und baut TomSelect darüber. TomSelect liest dabei den `disabled`-Zustand des `<select>` aus – der ist bereits `true` – und rendert das Widget **inaktiv/ausgegraut**.
3. Wählt man jetzt ein Feld, setzt `toggleInputs()` zwar `select.disabled = false` zurück, **aber TomSelect beobachtet diese Property-Änderung nicht** und bleibt deaktiviert. Ergebnis: das Auswahlmenü ist tot.

Kurz gesagt: TomSelect wird im deaktivierten Zustand geboren und erfährt nie, dass es wieder aktiv werden soll.

## Der Fix

In `bulk_edit_form_controller.js#toggleInputs()` treiben wir jetzt zusätzlich die **eigene API von TomSelect** an. Wenn ein `<select>` eine `tomselect`-Instanz hat, rufen wir `enable()` bzw. `disable()` auf – passend dazu, ob das Feld gerade aktiv ist:

```js
input.disabled = !matches
if (input.tomselect) {
  if (matches) {
    input.tomselect.enable()
  } else {
    input.tomselect.disable()
  }
}
```

Damit wird das Widget des aktiven Feldes wieder klickbar, und die inaktiven bleiben sauber deaktiviert (werden also weiterhin nicht mitgesendet). Die Lösung ist robust gegenüber der Verbindungs-Reihenfolge der Controller – egal ob TomSelect vor oder nach dem Form-Controller startet.

## Tests

Neuer System-Test (Cuprite) in `test/system/bulk_edits_test.rb`:
**„choosing a collection field reveals an interactive value picker"** – wählt nacheinander die Felder *Strategien* und *Phänomene* und prüft, dass das jeweilige TomSelect-Widget **nicht** mehr den Zustand `.ts-wrapper.disabled` hat.

- Der Test **schlägt ohne den Fix fehl** (`found 1 match: ".ts-wrapper.disabled"`) und **läuft mit dem Fix grün** – die Regression ist also abgesichert.
- Lokal 3× hintereinander stabil grün (keine Flakiness).
- Die komplette System-Test-Suite (272 Tests) sowie die Bulk-Edit-Unit-/Request-/Service-Tests laufen grün.
- `standardrb` ohne Beanstandungen.

## Geänderte Dateien

- `app/javascript/controllers/bulk_edit_form_controller.js` – Fix
- `test/system/bulk_edits_test.rb` – Regressionstest

🤖 Generated with [Claude Code](https://claude.com/claude-code)
