### PR TITLE
CI: bump actions/checkout to v7 (Node 24)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up SSH keys
         uses: webfactory/ssh-agent@v0.10.0


### PR DESCRIPTION
## TL;DR

Bumps `actions/checkout@v4` → `@v7` in `.github/workflows/ci-cd.yml` to clear the Node.js 20 deprecation warning. v7 runs on the Node 24 runtime natively.

## Why

The post-merge CI run logged:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4.

`actions/checkout@v4` declares the Node 20 runtime, which GitHub is phasing out. v7 (the current major) declares Node 24, so the warning goes away. It also matches the era of the already-pinned `actions/upload-artifact@v7.0.1` in the same file. Both checkout steps (the `test` job and the `deploy` job) are bumped.

## Scope

Only the active workflow (`ci-cd.yml`) is touched. The sibling `.github/workflows/auto-merge-minor` file has no `.yml`/`.yaml` extension, so GitHub never runs it — its older `checkout@v2` is dormant and left as-is.

## Verification

Version-only change; CI on this PR exercises the bumped `checkout@v7`.